### PR TITLE
Miscellaneous fixes to project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ bin/
 obj/
 .vs/
 .vscode/
+.idea/
 *.user
 *.suo
 Properties/
@@ -16,6 +17,10 @@ tmp/
 Extensions/
 dlbackend/
 *.debug
+
+# Symbolic link overrides
+/Models
+/Output
 
 # Python
 __pycache__/

--- a/src/Pages/Text2Image.cshtml
+++ b/src/Pages/Text2Image.cshtml
@@ -189,11 +189,11 @@
         <div class="t2i-mid-split-bar splitter-bar" id="t2i-mid-split-bar"><div class="t2i-split-quickbutton t2i-mid-split-quickbutton" id="t2i-mid-split-quickbutton">&#x290B;</div></div>
         <div class="t2i-bottom-bar" id="t2i_bottom_bar" style="line-height:1.5">
             <div class="bottom-info-bar-container">
-                <span class="bottom-info-bar-component"><span><span class="other_info_span" id="other_info_span" style="min-height: 1rem"></span></span>
+                <span class="bottom-info-bar-component"><span class="other_info_span" id="other_info_span" style="min-height: 1rem"></span></span>
                 <span class="bottom-info-bar-component"><b class="translate">Model</b>: <select class="auto-dropdown current_model_view" onchange="autoSelectWidth(this)" id="current_model"></select></span>
                 <span class="bottom-info-bar-component" style="display:none;" id="current_presets_wrapper"><span><b class="translate">Current presets</b><span id="preset_info_slot"></span>: </span> <span id="current_preset_list_view"></span></span>
                 <span class="bottom-info-bar-component" style="display:none;" id="current_loras_wrapper"><span class="translate"><b>Current LoRAs</b><span id="lora_info_slot"></span>: </span> <span id="current_lora_list_view"></span></span>
-                <span class="bottom-info-bar-component"><span><span class="num_jobs_span" id="num_jobs_span" style="min-height: 1rem"></span></span>
+                <span class="bottom-info-bar-component"><span class="num_jobs_span" id="num_jobs_span" style="min-height: 1rem"></span></span>
             </div>
             <ul class="nav nav-tabs" role="tablist" id="bottombartabcollection">
                 <li class="nav-item" role="presentation">
@@ -231,7 +231,7 @@
                 <div class="modal modal-fullscreen imageview_popup_modal_background" id="image_fullview_modal">
                     <div id="image_fullview_modal_content" style="width:fit-content;margin:auto;"></div>
                     <div style="position: fixed; top: 1rem; right: 10%; width: 0; height: 0">
-                        <span class="text_button translate" onclick="imageFullView.close()">[Close]</button>
+                        <span class="text_button translate" onclick="imageFullView.close()">[Close]</span>
                     </div>
                 </div>
                 <div class="tab-pane genpage-bottom-tab" id="Presets-Tab" role="tabpanel">


### PR DESCRIPTION
Contains the following minor changes/fixes:
1. Added Models/Output symlink to .gitignore. Useful when using multiple applications sharing models and output folders. Existing gitignore only excludes actual Models/Output folder and not symlinks (which are seen as files instead)
2. There were a few extra unclosed span tags in t2i page, now removed.
3. There was one span tag closed with </button>. This is now fixed.

Note, for (2) and (3), browser DOM manager seem to safely 'fix' this at runtime, so a code change was not strictly necessary. However, this fix removes the errors from polluting the IDE analysis results.