### PR TITLE
#Windows - Add the `/b` switch to `exit` calls in `install-windows.bat`

### DIFF
--- a/install-windows.bat
+++ b/install-windows.bat
@@ -5,13 +5,13 @@ cd /d "%~dp0"
 if exist SwarmUI (
     echo SwarmUI is already installed in this folder. If this is incorrect, delete the 'SwarmUI' folder and try again.
     pause
-    exit
+    exit /b
 )
 
 if exist SwarmUI.sln (
     echo SwarmUI is already installed in this folder. If this is incorrect, delete 'SwarmUI.sln' and try again.
     pause
-    exit
+    exit /b
 )
 
 winget install Microsoft.DotNet.SDK.8 --accept-source-agreements --accept-package-agreements


### PR DESCRIPTION
The `/b` switch tells `exit` to exit the current script normally, but not close the command prompt if (and only if) it was a freestanding process.  This fixes errors in the windows install script from closing the command prompt if it did not launch the window.

If the command prompt was launched to run the script (by clicking on the `install-windows.bat` file in `Explorer`, for example), the window will continue to close normally after this change.