### PR TITLE
fix: use native resolution for segmentation/inpainting ( #19 )

### DIFF
--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGenerator.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGenerator.cs
@@ -291,7 +291,7 @@ public class WorkflowGenerator
     /// <param name="vae">The relevant VAE.</param>
     /// <param name="threshold">Optional minimum value threshold.</param>
     /// <returns>(boundsNode, croppedMask, maskedLatent).</returns>
-    public (string, string, string) CreateImageMaskCrop(JArray mask, JArray image, int growBy, JArray vae, double threshold = 0.01, double thresholdMax = 1)
+    public (string, string, string) CreateImageMaskCrop(JArray mask, JArray image, int growBy, JArray vae, double threshold = 0.01, double thresholdMax = 1, bool fromSegmentation = false)
     {
         if (threshold > 0)
         {
@@ -327,9 +327,9 @@ public class WorkflowGenerator
         string scaledImage = CreateNode("SwarmImageScaleForMP", new JObject()
         {
             ["image"] = new JArray() { croppedImage, 0 },
-            ["width"] = UserInput.Get(T2IParamTypes.Width, 1024),
-            ["height"] = UserInput.GetImageHeight(),
-            ["can_shrink"] = false
+            ["width"] = UserInput.GetModelForInpainting(fromSegmentation)?.StandardHeight,
+            ["height"] = UserInput.GetModelForInpainting(fromSegmentation)?.StandardWidth,
+            ["can_shrink"] = true
         });
         string vaeEncoded = CreateVAEEncode(vae, [scaledImage, 0], null, true);
         string masked = CreateNode("SetLatentNoiseMask", new JObject()

--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGenerator.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGenerator.cs
@@ -291,7 +291,7 @@ public class WorkflowGenerator
     /// <param name="vae">The relevant VAE.</param>
     /// <param name="threshold">Optional minimum value threshold.</param>
     /// <returns>(boundsNode, croppedMask, maskedLatent).</returns>
-    public (string, string, string) CreateImageMaskCrop(JArray mask, JArray image, int growBy, JArray vae, double threshold = 0.01, double thresholdMax = 1, bool fromSegmentation = false)
+    public (string, string, string) CreateImageMaskCrop(JArray mask, JArray image, int growBy, JArray vae, T2IModel model, double threshold = 0.01, double thresholdMax = 1)
     {
         if (threshold > 0)
         {
@@ -327,8 +327,8 @@ public class WorkflowGenerator
         string scaledImage = CreateNode("SwarmImageScaleForMP", new JObject()
         {
             ["image"] = new JArray() { croppedImage, 0 },
-            ["width"] = UserInput.GetModelForInpainting(fromSegmentation)?.StandardHeight,
-            ["height"] = UserInput.GetModelForInpainting(fromSegmentation)?.StandardWidth,
+            ["width"] = model?.StandardWidth <= 0 ? UserInput.Get(T2IParamTypes.Width, 1024) : model.StandardWidth,
+            ["height"] = model?.StandardWidth <= 0 ? UserInput.GetImageHeight() : model.StandardHeight,
             ["can_shrink"] = true
         });
         string vaeEncoded = CreateVAEEncode(vae, [scaledImage, 0], null, true);

--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
@@ -1032,7 +1032,7 @@ public class WorkflowGeneratorSteps
                         });
                         g.CreateImageSaveNode([imageNode, 0], g.GetStableDynamicID(50000, 0));
                     }
-                    (string boundsNode, string croppedMask, string masked) = g.CreateImageMaskCrop([segmentNode, 0], g.FinalImageOut, 8, vae, thresholdMax: g.UserInput.Get(T2IParamTypes.SegmentThresholdMax, 1));
+                    (string boundsNode, string croppedMask, string masked) = g.CreateImageMaskCrop([segmentNode, 0], g.FinalImageOut, 8, vae, thresholdMax: g.UserInput.Get(T2IParamTypes.SegmentThresholdMax, 1), fromSegmentation: true);
                     g.EnableDifferential();
                     (model, clip) = g.LoadLorasForConfinement(part.ContextID, model, clip);
                     JArray prompt = g.CreateConditioning(part.Prompt, clip, t2iModel, true);

--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
@@ -293,7 +293,7 @@ public class WorkflowGeneratorSteps
                             g.FinalInputImage = [decoded, 0];
                             g.InitialImageIsAlteredAsLatent = false;
                         }
-                        g.MaskShrunkInfo = g.CreateImageMaskCrop(g.FinalMask, g.FinalInputImage, shrinkGrow, g.FinalVae);
+                        g.MaskShrunkInfo = g.CreateImageMaskCrop(g.FinalMask, g.FinalInputImage, shrinkGrow, g.FinalVae, g.FinalLoadedModel);
                         g.FinalLatentImage = [g.MaskShrunkInfo.Item3, 0];
                     }
                     else
@@ -1032,7 +1032,7 @@ public class WorkflowGeneratorSteps
                         });
                         g.CreateImageSaveNode([imageNode, 0], g.GetStableDynamicID(50000, 0));
                     }
-                    (string boundsNode, string croppedMask, string masked) = g.CreateImageMaskCrop([segmentNode, 0], g.FinalImageOut, 8, vae, thresholdMax: g.UserInput.Get(T2IParamTypes.SegmentThresholdMax, 1), fromSegmentation: true);
+                    (string boundsNode, string croppedMask, string masked) = g.CreateImageMaskCrop([segmentNode, 0], g.FinalImageOut, 8, vae, g.FinalLoadedModel, thresholdMax: g.UserInput.Get(T2IParamTypes.SegmentThresholdMax, 1));
                     g.EnableDifferential();
                     (model, clip) = g.LoadLorasForConfinement(part.ContextID, model, clip);
                     JArray prompt = g.CreateConditioning(part.Prompt, clip, t2iModel, true);

--- a/src/Text2Image/T2IParamInput.cs
+++ b/src/Text2Image/T2IParamInput.cs
@@ -454,13 +454,6 @@ public class T2IParamInput
         return Get(T2IParamTypes.Height, 512);
     }
 
-    /// <summary>Get the right model for inpainting depending on the current operation</summary>
-    /// <remarks>Segmentation use refiner Model when enabled but inpainting does not</remarks>
-    public T2IModel GetModelForInpainting(bool fromSegmentation)
-    {
-        return fromSegmentation ? Get(T2IParamTypes.RefinerModel, Get(T2IParamTypes.Model)) : Get(T2IParamTypes.Model);
-    }
-
     /// <summary>Returns a perfect duplicate of this parameter input, with new reference addresses.</summary>
     public T2IParamInput Clone()
     {

--- a/src/Text2Image/T2IParamInput.cs
+++ b/src/Text2Image/T2IParamInput.cs
@@ -454,6 +454,13 @@ public class T2IParamInput
         return Get(T2IParamTypes.Height, 512);
     }
 
+    /// <summary>Get the right model for inpainting depending on the current operation</summary>
+    /// <remarks>Segmentation use refiner Model when enabled but inpainting does not</remarks>
+    public T2IModel GetModelForInpainting(bool fromSegmentation)
+    {
+        return fromSegmentation ? Get(T2IParamTypes.RefinerModel, Get(T2IParamTypes.Model)) : Get(T2IParamTypes.Model);
+    }
+
     /// <summary>Returns a perfect duplicate of this parameter input, with new reference addresses.</summary>
     public T2IParamInput Clone()
     {


### PR DESCRIPTION
As discussed in #19 Segmentation and Inpainting (with Mask Shrink Grow) use the current image resolution to render the masked area.

### This fix ensure that the render is done with the right model resolution depending on the settings : 

- Current model resolution for segmentation without refiner
- Refiner resolution (when enabled) for segmention
- Current model resolution for inpainting with or without refiner as the inpaint is done before the refiner pass