### PR TITLE
[Feature] new option for segmentation : Sharper inpaint 

### DIFF
--- a/src/Text2Image/T2IParamInput.cs
+++ b/src/Text2Image/T2IParamInput.cs
@@ -454,6 +454,13 @@ public class T2IParamInput
         return Get(T2IParamTypes.Height, 512);
     }
 
+    /// <summary>Get the right model for inpainting depending on the current operation</summary>
+    /// <remarks>Segmentation use refiner Model when enabled but inpainting does not</remarks>
+    public T2IModel GetModelForInpainting(bool fromSegmentation)
+    {
+        return fromSegmentation ? Get(T2IParamTypes.RefinerModel, Get(T2IParamTypes.Model)) : Get(T2IParamTypes.Model);
+    }
+
     /// <summary>Returns a perfect duplicate of this parameter input, with new reference addresses.</summary>
     public T2IParamInput Clone()
     {


### PR DESCRIPTION
### Option for segmentation : Sharper inpaint 

By default, Segmentation use a 'latent noise mask' node before render to better blend the inpaint part to the original image.
 
 It works great most of the time but as a result the inpainted image can be a little soft.
As an option, I wanted to enable the kind of sharpness you can obtain with Adetailler in Automatic1111.

To use this option, I propose adding a 'sharp-' prefix in the segment parameters:  \<segment:sharp-face\>

When using the '**sharp-**' prefix, we skip the latent noise mask to enable a more raw render which can result on a crisper image (that work very well for face inpainting).

For this to work, I've needed to replace the 'Threshold Mask' by a 'Feather mask'  for a smoother transition.

@mcmonkey4eva : I've tried keeping the Threshold mask before or after the Feather mask but I as a result the mask border is very apparent. I'm not sure why. Anyway, in the code the Feather mask is only enable when using the new option.

A few examples with and without the option (cropped):

![image](https://github.com/mcmonkeyprojects/SwarmUI/assets/63900078/0ae75027-a4a4-45e7-a316-1315669e795d)

Remark: This PR is based on PR #52 and should be reviewed after #52 is merged.