### PR TITLE
Fix File Browser Header Path Navigation Issue

### DIFF
--- a/src/wwwroot/js/genpage/browsers.js
+++ b/src/wwwroot/js/genpage/browsers.js
@@ -177,16 +177,14 @@ class GenPageBrowserClass {
             upButton.disabled = true;
             return pathGen;
         }
+        let rootPathSuffix = 'Root/';
         let partial = '';
-        for (let part of ("Root/" + path).split('/')) {
+        for (let part of (rootPathSuffix + path).split('/')) {
             partial += part + '/';
             let span = document.createElement('span');
             span.className = 'path-list-part';
             span.innerText = part;
-            let route = partial.substring(3, partial.length - 1);
-            if (route == '/') {
-                route = '';
-            }
+            let route = partial.substring(rootPathSuffix.length);
             let helper = new BrowserCallHelper(route, this.navCaller);
             span.onclick = helper.call.bind(helper);
             pathGen.appendChild(span);

--- a/src/wwwroot/js/genpage/browsers.js
+++ b/src/wwwroot/js/genpage/browsers.js
@@ -177,14 +177,14 @@ class GenPageBrowserClass {
             upButton.disabled = true;
             return pathGen;
         }
-        let rootPathSuffix = 'Root/';
+        let rootPathPrefix = 'Root/';
         let partial = '';
-        for (let part of (rootPathSuffix + path).split('/')) {
+        for (let part of (rootPathPrefix + path).split('/')) {
             partial += part + '/';
             let span = document.createElement('span');
             span.className = 'path-list-part';
             span.innerText = part;
-            let route = partial.substring(rootPathSuffix.length);
+            let route = partial.substring(rootPathPrefix.length);
             let helper = new BrowserCallHelper(route, this.navCaller);
             span.onclick = helper.call.bind(helper);
             pathGen.appendChild(span);


### PR DESCRIPTION
Fixed an issue where navigating to a folder by clicking on a folder name in the Header Path navigation (i.e. `Root/Folder/Names/Here/`), would incorrectly add a `t/` folder to the base of the path. We now correctly chop off all of the leading `Root/` prefix when building paths instead of only `Roo`, fixing this issue.