### PR TITLE
Add advanced IP-Adapter Start/End step% parameter controls.

### DIFF
--- a/src/BuiltinExtensions/ComfyUIBackend/ComfyUIBackendExtension.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/ComfyUIBackendExtension.cs
@@ -413,7 +413,7 @@ public class ComfyUIBackendExtension : Extension
 
     public static T2IRegisteredParam<bool> AITemplateParam, DebugRegionalPrompting, ShiftedLatentAverageInit;
 
-    public static T2IRegisteredParam<double> IPAdapterWeight, IPAdapterStartAt, IPAdapterEndAt, SelfAttentionGuidanceScale, SelfAttentionGuidanceSigmaBlur;
+    public static T2IRegisteredParam<double> IPAdapterWeight, IPAdapterStart, IPAdapterEnd, SelfAttentionGuidanceScale, SelfAttentionGuidanceSigmaBlur;
 
     public static T2IRegisteredParam<int> RefinerHyperTile, VideoFrameInterpolationMultiplier;
 
@@ -442,10 +442,10 @@ public class ComfyUIBackendExtension : Extension
         IPAdapterWeight = T2IParamTypes.Register<double>(new("IP-Adapter Weight", "Weight to use with IP-Adapter (if enabled).",
             "1", Min: -1, Max: 3, Step: 0.05, IgnoreIf: "1", FeatureFlag: "ipadapter", Group: T2IParamTypes.GroupRevision, ViewType: ParamViewType.SLIDER, OrderPriority: 16
             ));
-        IPAdapterStartAt = T2IParamTypes.Register<double>(new("IP-Adapter Start", "When to start applying IP-Adapter, as a fraction of steps (if enabled). \nFor example, 0.25 starts applying a quarter (25&#37;) of the way through. Must be less than IP-Adapter End.",
+        IPAdapterStart = T2IParamTypes.Register<double>(new("IP-Adapter Start", "When to start applying IP-Adapter, as a fraction of steps (if enabled).\nFor example, 0.25 starts applying a quarter (25%) of the way through. Must be less than IP-Adapter End.",
             "0", IgnoreIf: "0", Min: 0.0, Max: 1.0, Step: 0.05, FeatureFlag: "ipadapter", Group: T2IParamTypes.GroupRevision, ViewType: ParamViewType.SLIDER, OrderPriority: 17, IsAdvanced: true, Examples: ["0", "0.2", "0.5"]
             ));
-        IPAdapterEndAt = T2IParamTypes.Register<double>(new("IP-Adapter End", "When to stop applying IP-Adapter, as a fraction of steps (if enabled). \nFor example, 0.5 stops applying halfway (50&#37;) through. Must be greater than IP-Adapter Start.",
+        IPAdapterEnd = T2IParamTypes.Register<double>(new("IP-Adapter End", "When to stop applying IP-Adapter, as a fraction of steps (if enabled).\nFor example, 0.5 stops applying halfway (50%) through. Must be greater than IP-Adapter Start.",
             "1", IgnoreIf: "1",  Min: 0.0, Max: 1.0, Step: 0.05, FeatureFlag: "ipadapter", Group: T2IParamTypes.GroupRevision, ViewType: ParamViewType.SLIDER, OrderPriority: 18, IsAdvanced: true, Examples: ["1", "0.8", "0.5"]
             ));
         ComfyGroup = new("ComfyUI", Toggles: false, Open: false);

--- a/src/BuiltinExtensions/ComfyUIBackend/ComfyUIBackendExtension.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/ComfyUIBackendExtension.cs
@@ -413,7 +413,7 @@ public class ComfyUIBackendExtension : Extension
 
     public static T2IRegisteredParam<bool> AITemplateParam, DebugRegionalPrompting, ShiftedLatentAverageInit;
 
-    public static T2IRegisteredParam<double> IPAdapterWeight, SelfAttentionGuidanceScale, SelfAttentionGuidanceSigmaBlur;
+    public static T2IRegisteredParam<double> IPAdapterWeight, IPAdapterStartAt, IPAdapterEndAt, SelfAttentionGuidanceScale, SelfAttentionGuidanceSigmaBlur;
 
     public static T2IRegisteredParam<int> RefinerHyperTile, VideoFrameInterpolationMultiplier;
 
@@ -441,6 +441,12 @@ public class ComfyUIBackendExtension : Extension
             ));
         IPAdapterWeight = T2IParamTypes.Register<double>(new("IP-Adapter Weight", "Weight to use with IP-Adapter (if enabled).",
             "1", Min: -1, Max: 3, Step: 0.05, IgnoreIf: "1", FeatureFlag: "ipadapter", Group: T2IParamTypes.GroupRevision, ViewType: ParamViewType.SLIDER, OrderPriority: 16
+            ));
+        IPAdapterStartAt = T2IParamTypes.Register<double>(new("IP-Adapter Start", "When to start applying IP-Adapter, as a fraction of steps (if enabled). \nFor example, 0.25 starts applying a quarter (25&#37;) of the way through. Must be less than IP-Adapter End.",
+            "0", IgnoreIf: "0", Min: 0.0, Max: 1.0, Step: 0.05, FeatureFlag: "ipadapter", Group: T2IParamTypes.GroupRevision, ViewType: ParamViewType.SLIDER, OrderPriority: 17, IsAdvanced: true, Examples: ["0", "0.2", "0.5"]
+            ));
+        IPAdapterEndAt = T2IParamTypes.Register<double>(new("IP-Adapter End", "When to stop applying IP-Adapter, as a fraction of steps (if enabled). \nFor example, 0.5 stops applying halfway (50&#37;) through. Must be greater than IP-Adapter Start.",
+            "1", IgnoreIf: "1",  Min: 0.0, Max: 1.0, Step: 0.05, FeatureFlag: "ipadapter", Group: T2IParamTypes.GroupRevision, ViewType: ParamViewType.SLIDER, OrderPriority: 18, IsAdvanced: true, Examples: ["1", "0.8", "0.5"]
             ));
         ComfyGroup = new("ComfyUI", Toggles: false, Open: false);
         ComfyAdvancedGroup = new("ComfyUI Advanced", Toggles: false, IsAdvanced: true, Open: false);

--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
@@ -552,14 +552,23 @@ public class WorkflowGeneratorSteps
                                 ["preset"] = ipAdapter
                             });
                         }
+
+                        double ipAdapterStartAt = g.UserInput.Get(ComfyUIBackendExtension.IPAdapterStartAt, 0.0);
+                        double ipAdapterEndAt = g.UserInput.Get(ComfyUIBackendExtension.IPAdapterEndAt, 1.0);
+                        if (ipAdapterStartAt >= ipAdapterEndAt) 
+                        {
+                            throw new InvalidDataException($"IP-Adapter Start must be less than IP-Adapter End.");
+                        }
+
                         string ipAdapterNode = g.CreateNode("IPAdapter", new JObject()
                         {
+
                             ["model"] = new JArray() { ipAdapterLoader, 0 },
                             ["ipadapter"] = new JArray() { ipAdapterLoader, 1 },
                             ["image"] = new JArray() { lastImage, 0 },
                             ["weight"] = g.UserInput.Get(ComfyUIBackendExtension.IPAdapterWeight, 1),
-                            ["start_at"] = 0.0,
-                            ["end_at"] = 1.0,
+                            ["start_at"] = ipAdapterStartAt,
+                            ["end_at"] = ipAdapterEndAt,
                             ["weight_type"] = "standard" // TODO: ...???
                         });
                         g.FinalModel = [ipAdapterNode, 0];

--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
@@ -553,9 +553,9 @@ public class WorkflowGeneratorSteps
                             });
                         }
 
-                        double ipAdapterStartAt = g.UserInput.Get(ComfyUIBackendExtension.IPAdapterStartAt, 0.0);
-                        double ipAdapterEndAt = g.UserInput.Get(ComfyUIBackendExtension.IPAdapterEndAt, 1.0);
-                        if (ipAdapterStartAt >= ipAdapterEndAt) 
+                        double ipAdapterStart = g.UserInput.Get(ComfyUIBackendExtension.IPAdapterStart, 0.0);
+                        double ipAdapterEnd = g.UserInput.Get(ComfyUIBackendExtension.IPAdapterEnd, 1.0);
+                        if (ipAdapterStart >= ipAdapterEnd) 
                         {
                             throw new InvalidDataException($"IP-Adapter Start must be less than IP-Adapter End.");
                         }
@@ -567,8 +567,8 @@ public class WorkflowGeneratorSteps
                             ["ipadapter"] = new JArray() { ipAdapterLoader, 1 },
                             ["image"] = new JArray() { lastImage, 0 },
                             ["weight"] = g.UserInput.Get(ComfyUIBackendExtension.IPAdapterWeight, 1),
-                            ["start_at"] = ipAdapterStartAt,
-                            ["end_at"] = ipAdapterEndAt,
+                            ["start_at"] = ipAdapterStart,
+                            ["end_at"] = ipAdapterEnd,
                             ["weight_type"] = "standard" // TODO: ...???
                         });
                         g.FinalModel = [ipAdapterNode, 0];


### PR DESCRIPTION
Users may now adjust when `IP-Adapter` will start and end in the generation process. These extra controls are hidden behind the `Advanced Options` checkbox by default.