### PR TITLE
Add Remove Image buttons to ReVision/IPAdapter prompt images

### DIFF
--- a/src/wwwroot/css/genpage.css
+++ b/src/wwwroot/css/genpage.css
@@ -838,7 +838,7 @@ body {
     transition: background-color 0.2s ease-out;
 }
 
-.alt-prompt-image-container-image {
+.alt-prompt-image {
     max-height: 128px;
     margin-right: 1px;
 }

--- a/src/wwwroot/css/genpage.css
+++ b/src/wwwroot/css/genpage.css
@@ -831,10 +831,50 @@ body {
 .alt-prompt-added-image-area {
     max-width: calc(100% - 7rem);
 }
-.alt-prompt-image {
+.alt-prompt-image-container {
+    display: inline-block;
+    position: relative;
+    background-color: color-mix(in srgb, transparent 80%, var(--background));
+    transition: background-color 0.2s ease-out;
+}
+
+.alt-prompt-image-container-image {
     max-height: 128px;
     margin-right: 1px;
 }
+
+.alt-prompt-image-container-remove-button {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    z-index: 100;
+    opacity: 0.7;
+    background-color: color-mix(in srgb, transparent 80%, var(--background));
+    border: none;
+    border-radius: 0.5rem;
+    padding-left: 0.2rem;
+    padding-right: 0.2rem;
+    padding-bottom: 0.2rem;
+    line-height: 0.8rem;
+    font-weight: bold;
+    color: var(--text);
+    transition: background-color 0.2s ease-out;
+    cursor: pointer;
+}
+
+.alt-prompt-image-container:hover .alt-prompt-image-container-remove-button {
+    opacity: 1.0;
+    background-color: color-mix(in srgb, transparent 50%, var(--background));
+    border: 1px solid red;
+}
+
+.alt-prompt-image-container-remove-button:hover {
+    opacity: 1.0;
+    background-color: color-mix(in srgb, red 70%, black) !important;
+    border: 1px solid black;
+    cursor: pointer;
+}
+
 .image-clear-button {
     vertical-align: middle;
     display: inline-block;

--- a/src/wwwroot/js/genpage/main.js
+++ b/src/wwwroot/js/genpage/main.js
@@ -1794,18 +1794,16 @@ function revisionAddImage(file) {
         let imageContainer = createDiv(null, 'alt-prompt-image-container');
         let imageRemoveButton = createSpan(null, 'alt-prompt-image-container-remove-button', '&times;');
         imageRemoveButton.addEventListener('click', (e) => {
-            e.currentTarget.parentElement.remove();
+            imageContainer.remove();
             autoRevealRevision();
             altPromptSizeHandleFunc();
-        }, {
-            once: true
         });
         imageRemoveButton.title = 'Remove this image';
         imageContainer.appendChild(imageRemoveButton);
         let imageObject = new Image();
         imageObject.src = data;
         imageObject.height = 128;
-        imageObject.className = 'alt-prompt-image-container-image';
+        imageObject.className = 'alt-prompt-image';
         imageObject.dataset.filedata = data;
         imageContainer.appendChild(imageObject);
         clearButton.style.display = '';

--- a/src/wwwroot/js/genpage/main.js
+++ b/src/wwwroot/js/genpage/main.js
@@ -1791,14 +1791,26 @@ function revisionAddImage(file) {
     let reader = new FileReader();
     reader.onload = (e) => {
         let data = e.target.result;
+        let imageContainer = createDiv(null, 'alt-prompt-image-container');
+        let imageRemoveButton = createSpan(null, 'alt-prompt-image-container-remove-button', '&times;');
+        imageRemoveButton.addEventListener('click', (e) => {
+            e.currentTarget.parentElement.remove();
+            autoRevealRevision();
+            altPromptSizeHandleFunc();
+        }, {
+            once: true
+        });
+        imageRemoveButton.title = 'Remove this image';
+        imageContainer.appendChild(imageRemoveButton);
         let imageObject = new Image();
         imageObject.src = data;
         imageObject.height = 128;
-        imageObject.className = 'alt-prompt-image';
+        imageObject.className = 'alt-prompt-image-container-image';
         imageObject.dataset.filedata = data;
+        imageContainer.appendChild(imageObject);
         clearButton.style.display = '';
         showRevisionInputs(true);
-        promptImageArea.appendChild(imageObject);
+        promptImageArea.appendChild(imageContainer);
         altPromptSizeHandleFunc();
     };
     reader.readAsDataURL(file);

--- a/src/wwwroot/js/genpage/params.js
+++ b/src/wwwroot/js/genpage/params.js
@@ -479,7 +479,7 @@ function getGenInput(input_overrides = {}, input_preoverrides = {}) {
             let container = findParentOfClass(elem, 'auto-input');
             let addedImageArea = container.querySelector('.added-image-area');
             addedImageArea.style.display = '';
-            let imgs = [...addedImageArea.querySelectorAll('.alt-prompt-image-container-image')].filter(c => c.tagName == "IMG");
+            let imgs = [...addedImageArea.querySelectorAll('.alt-prompt-image')].filter(c => c.tagName == "IMG");
             if (imgs.length > 0) {
                 input["promptimages"] = imgs.map(img => img.dataset.filedata).join('|');
             }
@@ -489,7 +489,7 @@ function getGenInput(input_overrides = {}, input_preoverrides = {}) {
         input['automaticvae'] = true;
     }
     let revisionImageArea = getRequiredElementById('alt_prompt_image_area');
-    let revisionImages = [...revisionImageArea.querySelectorAll('.alt-prompt-image-container-image')].filter(c => c.tagName == "IMG");
+    let revisionImages = [...revisionImageArea.querySelectorAll('.alt-prompt-image')].filter(c => c.tagName == "IMG");
     if (revisionImages.length > 0) {
         input["promptimages"] = revisionImages.map(img => img.dataset.filedata).join('|');
     }

--- a/src/wwwroot/js/genpage/params.js
+++ b/src/wwwroot/js/genpage/params.js
@@ -479,7 +479,7 @@ function getGenInput(input_overrides = {}, input_preoverrides = {}) {
             let container = findParentOfClass(elem, 'auto-input');
             let addedImageArea = container.querySelector('.added-image-area');
             addedImageArea.style.display = '';
-            let imgs = [...addedImageArea.children].filter(c => c.tagName == "IMG");
+            let imgs = [...addedImageArea.querySelectorAll('.alt-prompt-image-container-image')].filter(c => c.tagName == "IMG");
             if (imgs.length > 0) {
                 input["promptimages"] = imgs.map(img => img.dataset.filedata).join('|');
             }
@@ -489,7 +489,7 @@ function getGenInput(input_overrides = {}, input_preoverrides = {}) {
         input['automaticvae'] = true;
     }
     let revisionImageArea = getRequiredElementById('alt_prompt_image_area');
-    let revisionImages = [...revisionImageArea.children].filter(c => c.tagName == "IMG");
+    let revisionImages = [...revisionImageArea.querySelectorAll('.alt-prompt-image-container-image')].filter(c => c.tagName == "IMG");
     if (revisionImages.length > 0) {
         input["promptimages"] = revisionImages.map(img => img.dataset.filedata).join('|');
     }


### PR DESCRIPTION
Users may now remove specific uploaded prompt images by clicking a 'X' button in the top right of images. Previously it was only possible to remove all uploaded images.

See #61 for more details.