### PR TITLE
Normalize 'batchId' format.

### DIFF
--- a/src/BuiltinExtensions/GridGenerator/Assets/grid_gen.js
+++ b/src/BuiltinExtensions/GridGenerator/Assets/grid_gen.js
@@ -341,6 +341,7 @@ class GridGenClass {
 
     doGenerate() {
         resetBatchIfNeeded();
+        let batch_id = mainGenHandler.batchesEver++;
         let startTime = Date.now();
         let generatedCount = 0;
         let getOpt = (o) => getRequiredElementById('grid-gen-opt-' + o).checked;
@@ -381,7 +382,7 @@ class GridGenClass {
                 let timeDiff = timeNow - timeLastGenHit;
                 timeLastGenHit = timeNow;
                 mainGenHandler.appendGenTimeFrom(timeDiff / 1000);
-                gotImageResult(data.image, data.metadata);
+                gotImageResult(data.image, data.metadata, `${batch_id}_${data.batch_index}`);
                 generatedCount++;
                 let timeProgress = Math.round((Date.now() - startTime) / 1000);
                 let rate = Math.round(generatedCount / timeProgress * 100) / 100;

--- a/src/BuiltinExtensions/GridGenerator/GridGeneratorExtension.cs
+++ b/src/BuiltinExtensions/GridGenerator/GridGeneratorExtension.cs
@@ -533,7 +533,7 @@ public class GridGeneratorExtension : Extension
                 });
                 Logs.Info("Generated, saving...");
                 Image outImg = new(gridImg);
-                int batchId = xAxis.Count * yAxis.Count * y2Axis.Count;
+                int batchId = (xAxis.Count * yAxis.Count * y2Axis.Count) + 1;
                 Logs.Verbose("Apply metadata...");
                 (outImg, string metadata) = session.ApplyMetadata(outImg, grid.InitialParams, batchId);
                 Logs.Verbose("Metadata applied, save to file...");

--- a/src/BuiltinExtensions/ImageBatchTool/Assets/image_batcher.js
+++ b/src/BuiltinExtensions/ImageBatchTool/Assets/image_batcher.js
@@ -3,6 +3,7 @@ class ImageBatcherClass {
 
     doGenerate() {
         resetBatchIfNeeded();
+        let batch_id = mainGenHandler.batchesEver++;
         let inData = {
             'baseParams': getGenInput(),
             'input_folder': getRequiredElementById('ext_image_batcher_inputfolder').value,
@@ -14,7 +15,7 @@ class ImageBatcherClass {
         };
         makeWSRequestT2I('ImageBatchRun', inData, data => {
             if (data.image) {
-                gotImageResult(data.image, data.metadata);
+                gotImageResult(data.image, data.metadata, `${batch_id}_${data.batch_index}`);
             }
         });
     }


### PR DESCRIPTION
GridGen and ImageEditBatcher used `batchNumber` and the regular image generator used `batchNumber_batchIndex`.  Since all of these support multiple images per patch, I have normalized this to `batchNumber_batchIndex`.

Also fixed GridGen `GRID_IMAGE` images having the same `batchIndex` as the last image in the batch. These images now have a `batchIndex` one larger.