### PR TITLE
Fix deadlock in `SessionHandler.GetUser()`

### DIFF
--- a/src/Accounts/SessionHandler.cs
+++ b/src/Accounts/SessionHandler.cs
@@ -124,15 +124,15 @@ public class SessionHandler
         {
             userId = "_";
         }
-        return Users.GetOrCreate(userId, () =>
+        lock (DBLock)
         {
-            lock (DBLock)
+            return Users.GetOrCreate(userId, () =>
             {
                 User.DatabaseEntry userData = UserDatabase.FindById(userId);
                 userData ??= new() { ID = userId, RawSettings = "\n" };
                 return new(this, userData);
-            }
-        });
+            });
+        }
     }
 
     /// <summary>Tries to get the session for an id.</summary>


### PR DESCRIPTION
Basic explanation:

Thread 1: `CreateAdminSession()`
- Calls into `GetUser()` without a lock.
- `GetUser()` calls into `Users.GetOrCreate()` which locks Users internally.
- `Users.GetOrCreate()` tries to lock `DBLock`, but it is locked, so it blocks.
- `Users.GetOrCreate()` is blocking all calls to until `DBLock` is available/unlocked.

Thread 2: `TryGetSession()`
- Locks `DBLock` (almost) immediately.
- Calls into `GetUser()` with `DBLock` already locked.
- Calls into `Users.GetOrCreate()` but access is locked so it blocks.
- `DBLock` is is locked until `Users.GetOrCreate()`'s internal lock is available/unlocked.

Thus, `DBLock` and `Users.GetOrCreate()` can be both accessed and locked out-of-order, causing a deadlock.

One solution: always lock `DBLock` before accessing `Users.GetOrCreate()`.  Guarantees the same thread-access-safety, but creates a stable order preventing one lock from blocking the other. Disadvantage: two locks.

Alternative solution: Do not lock access to `UserDatabase` at all, since `Users.GetOrCreate()` is already locking access to it.  Disadvantage: Every call to `UserDatabase` _MUST_ go through calls to the `Users` dictionary to guarantee it uses its `ConcurrentDictionary` lock.