### PR TITLE
Add View Grid option to imagehistorybrowser-header

### DIFF
--- a/src/wwwroot/js/genpage/browsers.js
+++ b/src/wwwroot/js/genpage/browsers.js
@@ -180,6 +180,18 @@ class GenPageBrowserClass {
         let rootPathPrefix = 'Root/';
         let partial = '';
         for (let part of (rootPathPrefix + path).split('/')) {
+            if (part.includes('grid-')) {
+                let gridLink = document.createElement('a');
+                gridLink.href = `/View/local/${path}/index.html`;
+                gridLink.target = '_blank';
+                gridLink.className = 'grid-view-link';
+                gridLink.textContent = 'View Grid';
+                // I wanted the view grid link to come before the path area so using prepend here.
+                // happy to change this if needed.
+                pathGen.prepend(document.createTextNode(' • '));
+                pathGen.prepend(gridLink);
+                pathGen.prepend(document.createTextNode('  '));
+            }
             partial += part + '/';
             let span = document.createElement('span');
             span.className = 'path-list-part';
@@ -540,7 +552,7 @@ class GenPageBrowserClass {
             if (!this.showDisplayFormat) {
                 formatSelector.style.display = 'none';
             }
-            let buttons = createSpan(`${this.id}-button-container`, 'browser-header-buttons', 
+            let buttons = createSpan(`${this.id}-button-container`, 'browser-header-buttons',
                 `<button id="${this.id}_refresh_button" title="Refresh" class="refresh-button translate translate-no-text">&#x21BB;</button>\n`
                 + `<button id="${this.id}_up_button" class="refresh-button translate translate-no-text" disabled autocomplete="off" title="Go back up 1 folder">&#x21d1;</button>\n`
                 + `<span class="translate">Depth: <input id="${this.id}_depth_input" class="depth-number-input translate translate-no-text" type="number" min="1" max="10" value="${this.depth}" title="Depth of subfolders to show" autocomplete="false"></span>\n`


### PR DESCRIPTION
I couldn't find a way to get back to the grid html after I navigated away from the Grid Generation tool view, so I tried to make it a little easier to get to that when I'm not sitting at my main computer with access to the file browser.
![Screenshot 2024-07-30 at 10 12 45 AM](https://github.com/user-attachments/assets/e9c0257a-c819-4240-b5e3-acf0f098d2b1)
