### PR TITLE
Adding --rm to launch-docker.sh

### DIFF
--- a/launch-docker.sh
+++ b/launch-docker.sh
@@ -3,7 +3,8 @@
 docker build -t swarmui .
 
 # add "--network=host" if you want to access other services on the host network (eg a separated comfy instance)
-docker run -it \
+docker run -it \    
+    --rm \
     --name swarmui \
     --mount source=swarmdata,target=/Data \
     --mount source=swarmbackend,target=/dlbackend \


### PR DESCRIPTION
Adding --rm will ensure that the container is deleted when stopped. This avoids to manually delete the container  created in the previous run before launching the server with this script