### PR TITLE
Feature to use dimensions of the Init Image when doing Img2img

### DIFF
--- a/src/Text2Image/T2IParamInput.cs
+++ b/src/Text2Image/T2IParamInput.cs
@@ -30,6 +30,17 @@ public class T2IParamInput
         },
         input =>
         {
+            if (input.TryGet(T2IParamTypes.UseInitImageDimensions, out bool useInitImageDimensions) && useInitImageDimensions && input.TryGet(T2IParamTypes.InitImage, out Image image) && image != null)
+            {
+                //fixme: "image.ToIS" reloads the image every time, it's not cached or anything
+                var toIs = image.ToIS;
+                input.Set(T2IParamTypes.Width, toIs.Width);
+                input.Set(T2IParamTypes.Height, toIs.Height);
+                input.Remove(T2IParamTypes.AltResolutionHeightMult);
+            }
+        },
+        input =>
+        {
             if (input.TryGet(T2IParamTypes.RawResolution, out string res))
             {
                 (string widthText, string heightText) = res.BeforeAndAfter('x');
@@ -491,6 +502,12 @@ public class T2IParamInput
         {
             return int.Parse(res.Before('x'));
         }
+        if (TryGet(T2IParamTypes.UseInitImageDimensions, out bool useInitImageDimensions) && useInitImageDimensions &&
+            TryGet(T2IParamTypes.InitImage, out Image image) && image != null)
+        {
+            //fixme: "image.ToIS" reloads the image every time, it's not cached or anything
+            return image.ToIS.Width;
+        }
         return Get(T2IParamTypes.Width, 512);
     }
 
@@ -500,6 +517,12 @@ public class T2IParamInput
         if (TryGet(T2IParamTypes.RawResolution, out string res))
         {
             return int.Parse(res.After('x'));
+        }
+        if (TryGet(T2IParamTypes.UseInitImageDimensions, out bool useInitImageDimensions) && useInitImageDimensions &&
+            TryGet(T2IParamTypes.InitImage, out Image image) && image != null)
+        {
+            //fixme: "image.ToIS" reloads the image every time, it's not cached or anything
+            return image.ToIS.Height;
         }
         if (TryGet(T2IParamTypes.AltResolutionHeightMult, out double val) && TryGet(T2IParamTypes.Width, out int width))
         {

--- a/src/Text2Image/T2IParamTypes.cs
+++ b/src/Text2Image/T2IParamTypes.cs
@@ -386,7 +386,7 @@ public class T2IParamTypes
         InitImage = Register<Image>(new("Init Image", "Init-image, to edit an image using diffusion.\nThis process is sometimes called 'img2img' or 'Image To Image'.",
             null, OrderPriority: -5, Group: GroupInitImage, ChangeWeight: 2
             ));
-        UseInitImageDimensions = Register<bool>(new("Use Dimensions of Init Image", "Use the dimensions of the Init Image instead of the specified resolution.\nDimensions may be rounded to a multiple of 8.", "false", IgnoreIf: "false", Group: GroupInitImage, OrderPriority: -4.9));
+        UseInitImageDimensions = Register<bool>(new("Use Dimensions of Init Image", "Use the dimensions of the Init Image instead of the specified resolution.\nDimensions may be rounded to a multiple of 8.", "false", IgnoreIf: "false", Group: GroupInitImage, OrderPriority: -4.9, HideFromMetadata: true));
         InitImageCreativity = Register<double>(new("Init Image Creativity", "Higher values make the generation more creative, lower values follow the init image closer.\nSometimes referred to as 'Denoising Strength' for 'img2img'.",
             "0.6", Min: 0, Max: 1, Step: 0.05, OrderPriority: -4.5, ViewType: ParamViewType.SLIDER, Group: GroupInitImage, Examples: ["0", "0.4", "0.6", "1"]
             ));

--- a/src/Text2Image/T2IParamTypes.cs
+++ b/src/Text2Image/T2IParamTypes.cs
@@ -285,6 +285,7 @@ public class T2IParamTypes
     public static T2IRegisteredParam<double> CFGScale, VariationSeedStrength, InitImageCreativity, InitImageResetToNorm, RefinerControl, RefinerUpscale, RefinerCFGScale, ReVisionStrength, AltResolutionHeightMult,
         FreeUBlock1, FreeUBlock2, FreeUSkip1, FreeUSkip2, GlobalRegionFactor, EndStepsEarly, SamplerSigmaMin, SamplerSigmaMax, SamplerRho, VideoAugmentationLevel, VideoCFG, VideoMinCFG, IP2PCFG2, RegionalObjectCleanupFactor, SigmaShift, SegmentThresholdMax, FluxGuidanceScale;
     public static T2IRegisteredParam<Image> InitImage, MaskImage;
+    public static T2IRegisteredParam<bool> UseInitImageDimensions;  //NEW
     public static T2IRegisteredParam<T2IModel> Model, RefinerModel, VAE, ReVisionModel, RegionalObjectInpaintingModel, SegmentModel, VideoModel, RefinerVAE;
     public static T2IRegisteredParam<List<string>> Loras, LoraWeights, LoraSectionConfinement;
     public static T2IRegisteredParam<List<Image>> PromptImages;
@@ -385,6 +386,7 @@ public class T2IParamTypes
         InitImage = Register<Image>(new("Init Image", "Init-image, to edit an image using diffusion.\nThis process is sometimes called 'img2img' or 'Image To Image'.",
             null, OrderPriority: -5, Group: GroupInitImage, ChangeWeight: 2
             ));
+        UseInitImageDimensions = Register<bool>(new("Use Dimensions of Init Image", "Use the dimensions of the Init Image instead of the specified resolution.\nDimensions may be rounded to a multiple of 8.", "false", IgnoreIf: "false", Group: GroupInitImage, OrderPriority: -4.9));
         InitImageCreativity = Register<double>(new("Init Image Creativity", "Higher values make the generation more creative, lower values follow the init image closer.\nSometimes referred to as 'Denoising Strength' for 'img2img'.",
             "0.6", Min: 0, Max: 1, Step: 0.05, OrderPriority: -4.5, ViewType: ParamViewType.SLIDER, Group: GroupInitImage, Examples: ["0", "0.4", "0.6", "1"]
             ));


### PR DESCRIPTION
For Issue #92

This adds a "Use Dimensions of Init Image" check box after the "Init Image" field.

When checked, it will use the dimensions of the Init Image instead of the selected resolution *unless* a size is specified in "Swarm Internal -> Raw Resolution", then it will pick that.