### PR TITLE
Add min queue size setting for Generate Forever

### DIFF
--- a/src/Core/Settings.cs
+++ b/src/Core/Settings.cs
@@ -341,6 +341,9 @@ public class Settings : AutoConfiguration
         [ConfigComment("Delay, in seconds, betweeen Generate Forever updates.\nIf the delay hits and a generation is still waiting, it will be skipped.\nDefault is 0.1 seconds.")]
         public double GenerateForeverDelay = 0.1;
 
+        [ConfigComment("Number of generations that Generate Forever should always keep queued up when enabled.\nUseful when using multiple backends to keep them all busy.\n")]
+        public double GenerateForeverQueueSize = 1;
+
         public class LanguagesImpl : SettingsOptionsAttribute.AbstractImpl
         {
             public override string[] GetOptions => LanguagesHelper.SortedList;

--- a/src/Core/Settings.cs
+++ b/src/Core/Settings.cs
@@ -341,8 +341,8 @@ public class Settings : AutoConfiguration
         [ConfigComment("Delay, in seconds, betweeen Generate Forever updates.\nIf the delay hits and a generation is still waiting, it will be skipped.\nDefault is 0.1 seconds.")]
         public double GenerateForeverDelay = 0.1;
 
-        [ConfigComment("Number of generations that Generate Forever should always keep queued up when enabled.\nUseful when using multiple backends to keep them all busy.\n")]
-        public double GenerateForeverQueueSize = 1;
+        [ConfigComment("Number of generations that Generate Forever should always keep queued up when enabled.\nUseful when using multiple backends to keep them all busy.")]
+        public int GenerateForeverQueueSize = 1;
 
         public class LanguagesImpl : SettingsOptionsAttribute.AbstractImpl
         {

--- a/src/wwwroot/js/genpage/main.js
+++ b/src/wwwroot/js/genpage/main.js
@@ -867,8 +867,8 @@ let genForeverInterval, genPreviewsInterval;
 
 let lastGenForeverParams = null;
 
-function doGenForeverOnce() {
-    if (num_current_gens > 0) {
+function doGenForeverOnce(minQueueSize) {
+    if (num_current_gens >= minQueueSize) {
         return;
     }
     let allParams = getGenInput();
@@ -887,9 +887,10 @@ function toggleGenerateForever() {
     if (isGeneratingForever) {
         button.innerText = 'Stop Generating';
         let delaySeconds = parseFloat(getUserSetting('generateforeverdelay', '0.1'));
+        let minQueueSize = Math.max(1, parseInt(getUserSetting('generateforeverqueuesize', '1')));
         let delayMs = Math.max(parseInt(delaySeconds * 1000), 1);
         genForeverInterval = setInterval(() => {
-            doGenForeverOnce();
+            doGenForeverOnce(minQueueSize);
         }, delayMs);
     }
     else {


### PR DESCRIPTION
Allow setting how many generations Generate Forever shall keep in the queue when enabled, useful when using multiple backends so you can keep all backends busy or however many you want to.

