### PR TITLE
Use SD3 Comfy ControlNet Node for Flux ControlNets

### DIFF
--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
@@ -795,7 +795,8 @@ public class WorkflowGeneratorSteps
                         });
                     }
                     string applyNode;
-                    if (g.CurrentCompatClass() == "stable-diffusion-v3-medium")
+                    string modelCompatClass = g.CurrentCompatClass();
+                    if (modelCompatClass == "stable-diffusion-v3-medium" || modelCompatClass == "flux-1")
                     {
                         applyNode = g.CreateNode("ControlNetApplySD3", new JObject()
                         {


### PR DESCRIPTION
Fixes a mat multiplication error when using the new InstantX / Shakker-Labs flux control nets. See: https://github.com/comfyanonymous/ComfyUI/issues/4669 for an example.

It seems the new InstantX flux controlnet models require using SD3 apply controlnet node.  From my own testing, it seems that other flux ControlNets can use the SD3 nodes just fine, so just always the SD3 node for flux.