### PR TITLE
Save Models in baseModel subfolder

### DIFF
--- a/src/Core/Settings.cs
+++ b/src/Core/Settings.cs
@@ -273,6 +273,9 @@ public class Settings : AutoConfiguration
         [ConfigComment("If true, folders will be discarded from starred image paths.")]
         public bool StarNoFolders = false;
 
+        [ConfigComment("Whether to automatically use the base model type as part of the model path when downloading using the 'Model Download' tool")]
+        public bool GroupDownloadedModelsByBaseType = false;
+
         public class ThemesImpl : SettingsOptionsAttribute.AbstractImpl
         {
             public override string[] GetOptions => [.. Program.Web.RegisteredThemes.Keys];

--- a/src/wwwroot/js/genpage/utiltab.js
+++ b/src/wwwroot/js/genpage/utiltab.js
@@ -259,6 +259,7 @@ class ModelDownloaderUtil {
                     'modelspec.author': rawData.creator.username,
                     'modelspec.description': `From <a href="${url}">${url}</a>\n${rawVersion.description || ''}\n${rawData.description}\n`,
                     'modelspec.date': rawVersion.createdAt,
+                    'modelspec.baseModel': rawVersion.baseModel,
                 };
                 if (rawVersion.trainedWords) {
                     metadata['modelspec.trigger_phrase'] = rawVersion.trainedWords.join(", ");


### PR DESCRIPTION
Add the functionality of reading baseModel from civitai metadata, and save models in their base model subfolders. This will look like: Models/Stable-diffusion/
  SDXL 1.0/
  SD1.5/
  Pony/
  Flux.1 D/
  Flux.1 F/
etc...

This is exactly the same changes as shared in Discord. I welcome any feedback and I'm happy to make any changes necessary. This is just my own little patch that I apply after any updates because I like my models to stay organized in basemodel subfolders since it helps identify them at a glance in the UI.