### PR TITLE
Add runtipi as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ The installation starts now and downloads the Stable Diffusion models from the i
     - Open your browser to `localhost:7801`
 - Note that it will forward the `Models` and `Output` directory, and will mount `Data` and `dlbackend` as independent persistent volumes.
 
+# One-click install via runtipi
+
+[Runtipi](https://runtipi.io) is a personal home server orchestrator that enables you to manage and run multiple services on a single server. Free and open-source, runtipi lets you install all your favorite self-hosted apps without the hassle of configuring and managing each service. One-click installs and updates for more than 200 popular apps.
+
+Install Runtipi on your server and open the App Store. Locate SwarmUI in the list, navigate to its store page, and click “Install”. In a few moments SwarmUI will be running (and exposed to the internet, if so configured) and ready for initial on-boarding.
+
 # Documentation
 
 See [the documentation folder](/docs/README.md).

--- a/README.md
+++ b/README.md
@@ -122,11 +122,9 @@ The installation starts now and downloads the Stable Diffusion models from the i
     - Open your browser to `localhost:7801`
 - Note that it will forward the `Models` and `Output` directory, and will mount `Data` and `dlbackend` as independent persistent volumes.
 
-# One-click install via runtipi
+# Install via runtipi
 
-[Runtipi](https://runtipi.io) is a personal home server orchestrator that enables you to manage and run multiple services on a single server. Free and open-source, runtipi lets you install all your favorite self-hosted apps without the hassle of configuring and managing each service. One-click installs and updates for more than 200 popular apps.
-
-Install Runtipi on your server and open the App Store. Locate SwarmUI in the list, navigate to its store page, and click “Install”. In a few moments SwarmUI will be running (and exposed to the internet, if so configured) and ready for initial on-boarding.
+[Runtipi](https://runtipi.io) users can find SwarmUI in their runtipi app store and the [available apps](https://runtipi.io/docs/apps-available) list.
 
 # Documentation
 


### PR DESCRIPTION
There's an open [PR](https://github.com/runtipi/runtipi-appstore/pull/4635) on the runtipi appstore that adds SwarmUI as a one-click install. Once merged _these_ changes to add runtipi as a one-click install option for SwarmUI become relevant. Hopefully they will also be desireable.

Happy to make any changes over there that would make this process more clear. Also totes understand if putting this into the official docs isn't of interest.

Of further note:

- I applied some "design" to the logo from Discord to produce the logo I used for runtipi. Happy to use something else
- In order to make SwarmUI suitable for runtipi I needed a publicly-available image, so I'm building one against my fork. Over coming releases I expect I'll automate that with some sort of workflow; if you'd rather build an image attached to the origin that's understandable; if I can be of assistance I'm happy to contribute.

I'll draft this PR until the one in the runtipi repo is merged - that can take some time....