### PR TITLE
Add Segmentation Ordering for Yolo segmentation

### DIFF
--- a/src/BuiltinExtensions/ComfyUIBackend/ExtraNodes/SwarmComfyExtra/SwarmYolo.py
+++ b/src/BuiltinExtensions/ComfyUIBackend/ExtraNodes/SwarmComfyExtra/SwarmYolo.py
@@ -80,7 +80,7 @@ class SwarmYoloDetection:
 
         sorted_indices_array = np.array(sortedindices)
         if sort_order in ["right-left", "bottom-top", "largest-smallest"]:
-            return np.argsort(sorted_indices_array)[::-1]
+            return np.argsort(sorted_indices_array)[::-1].copy()
         else:
             return np.argsort(sorted_indices_array)
 

--- a/src/BuiltinExtensions/ComfyUIBackend/ExtraNodes/SwarmComfyExtra/SwarmYolo.py
+++ b/src/BuiltinExtensions/ComfyUIBackend/ExtraNodes/SwarmComfyExtra/SwarmYolo.py
@@ -12,8 +12,7 @@ class SwarmYoloDetection:
                 "index": ("INT", { "default": 0, "min": 0, "max": 256, "step": 1 }),
             },
             "optional": {
-                "sort_order": (["left-right", "top-bottom", "largest-smallest", "default"], ),
-                "reverse_order": ("BOOL", { "default": False })
+                "sort_order": (["left-right", "right-left", "top-bottom", "bottom-top", "largest-smallest", "smallest-largest"], ),
             }
         }
 
@@ -21,7 +20,7 @@ class SwarmYoloDetection:
     RETURN_TYPES = ("MASK",)
     FUNCTION = "seg"
 
-    def seg(self, image, model_name, index, sort_order="default", reverse_order=False):
+    def seg(self, image, model_name, index, sort_order="left-right"):
         # TODO: Batch support?
         i = 255.0 * image[0].cpu().numpy()
         img = Image.fromarray(np.clip(i, 0, 255).astype(np.uint8))
@@ -45,55 +44,45 @@ class SwarmYoloDetection:
             masks = masks.data.cpu()
         masks = torch.nn.functional.interpolate(masks.unsqueeze(1), size=(image.shape[1], image.shape[2]), mode="bilinear").squeeze(1)
 
-        if sort_order != "default":
-            boxes = results[0].boxes
-            if boxes is not None and len(boxes) > 0:
-                sorted_indices = self.sort_masks(boxes, sort_order, reverse_order)
-                masks = masks[sorted_indices]
-            return (masks[0].unsqueeze(0), )
+        sortedindices = self.sort_masks(masks, sort_order)
+        sortedindices = torch.tensor(np.ascontiguousarray(sortedindices))
+        masks = masks[sortedindices]
 
         if index == 0:
             result = masks[0]
             for i in range(1, len(masks)):
                 result = torch.max(result, masks[i])
-            return (result, )
+            return (result.unsqueeze(0),)
         elif index > len(masks):
-            return (torch.zeros_like(masks[0]), )
+            return (torch.zeros_like(masks[0]).unsqueeze(0),)
         else:
-            sortedindices = []
-            for mask in masks:
-                sum_x = (torch.sum(mask, dim=0) != 0).to(dtype=torch.int)
-                val = torch.argmax(sum_x).item()
-                sortedindices.append(val)
-            sortedindices = np.argsort(sortedindices)
-            masks = masks[sortedindices]
-            return (masks[index - 1].unsqueeze(0), )
+            return (masks[index - 1].unsqueeze(0),)
 
-    def sort_masks(self, boxes, sort_order, reverse_order):
-        if sort_order == "left-right":
-            if reverse_order:
-                # Sort based on the maximum x-coordinate
-                sorted_indices = sorted(range(len(boxes)), key=lambda i: boxes[i].xyxy[0][2].item(), reverse=True)
-            else:
-                # Sort based on the minimum x-coordinate
-                sorted_indices = sorted(range(len(boxes)), key=lambda i: boxes[i].xyxy[0][0].item())
-        elif sort_order == "top-bottom":
-            if reverse_order:
-                # Sort based on the maximum y-coordinate
-                sorted_indices = sorted(range(len(boxes)), key=lambda i: boxes[i].xyxy[0][3].item(), reverse=True)
-            else:
-                # Sort based on the minimum y-coordinate
-                sorted_indices = sorted(range(len(boxes)), key=lambda i: boxes[i].xyxy[0][1].item())
-        elif sort_order == "largest-smallest":
-            if reverse_order:
-                # Sort based on the area (width * height) in ascending order
-                sorted_indices = sorted(range(len(boxes)), key=lambda i: (boxes[i].xyxy[0][2] - boxes[i].xyxy[0][0]).item() *
-                                                                  (boxes[i].xyxy[0][3] - boxes[i].xyxy[0][1]).item())
-            else:
-                # Sort based on the area (width * height) in descending order
-                sorted_indices = sorted(range(len(boxes)), key=lambda i: (boxes[i].xyxy[0][2] - boxes[i].xyxy[0][0]).item() *
-                                                              (boxes[i].xyxy[0][3] - boxes[i].xyxy[0][1]).item(), reverse=True)
-        return sorted_indices
+    def sort_masks(self, masks, sort_order):
+        sortedindices = []
+        for mask in masks:
+            match sort_order:
+                case "left-right":
+                    sum_x = (torch.sum(mask, dim=0) != 0).to(dtype=torch.int)
+                    val = torch.argmax(sum_x).item()
+                case "right-left":
+                    sum_x = (torch.sum(mask, dim=0) != 0).to(dtype=torch.int)
+                    val = mask.shape[1] - torch.argmax(torch.flip(sum_x, [0])).item() - 1
+                case "top-bottom":
+                    sum_y = (torch.sum(mask, dim=1) != 0).to(dtype=torch.int)
+                    val = torch.argmax(sum_y).item()
+                case "bottom-top":
+                    sum_y = (torch.sum(mask, dim=1) != 0).to(dtype=torch.int)
+                    val = mask.shape[0] - torch.argmax(torch.flip(sum_y, [0])).item() - 1
+                case "largest-smallest" | "smallest-largest":
+                    val = torch.sum(mask).item()
+            sortedindices.append(val)
+
+        sorted_indices_array = np.array(sortedindices)
+        if sort_order in ["right-left", "bottom-top", "largest-smallest"]:
+            return np.argsort(sorted_indices_array)[::-1]
+        else:
+            return np.argsort(sorted_indices_array)
 
 NODE_CLASS_MAPPINGS = {
     "SwarmYoloDetection": SwarmYoloDetection,

--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
@@ -1054,12 +1054,17 @@ public class WorkflowGeneratorSteps
                         {
                             index = 0;
                         }
+                        string sortOrder = g.UserInput.Get(T2IParamTypes.SegmentationSortOrder, "default");
+                        bool reverseOrder = g.UserInput.Get(T2IParamTypes.ReverseSegmentationOrder, false);
                         segmentNode = g.CreateNode("SwarmYoloDetection", new JObject()
                         {
                             ["image"] = g.FinalImageOut,
                             ["model_name"] = fullname,
-                            ["index"] = index
+                            ["index"] = index,
+                            ["sort_order"] = sortOrder,
+                            ["reverse_order"] = reverseOrder
                         });
+
                     }
                     else
                     {

--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
@@ -384,7 +384,7 @@ public class WorkflowGeneratorSteps
                         });
                         g.FinalNegativePrompt = [zeroed, 0];
                     }
-                    if (!g.UserInput.TryGet(T2IParamTypes.Model, out T2IModel model) || model.ModelClass is null ||
+                    if (!g.UserInput.TryGet(T2IParamTypes.Model, out T2IModel model) || model.ModelClass is null || 
                         (model.ModelClass.CompatClass != "stable-diffusion-xl-v1"/* && model.ModelClass.CompatClass != "stable-diffusion-v3-medium"*/))
                     {
                         throw new SwarmUserErrorException($"Model type must be SDXL for ReVision (currently is {model?.ModelClass?.Name ?? "Unknown"}). Set ReVision Strength to 0 if you just want IP-Adapter.");
@@ -576,7 +576,7 @@ public class WorkflowGeneratorSteps
                         }
                         double ipAdapterStart = g.UserInput.Get(ComfyUIBackendExtension.IPAdapterStart, 0.0);
                         double ipAdapterEnd = g.UserInput.Get(ComfyUIBackendExtension.IPAdapterEnd, 1.0);
-                        if (ipAdapterStart >= ipAdapterEnd)
+                        if (ipAdapterStart >= ipAdapterEnd) 
                         {
                             throw new SwarmUserErrorException($"IP-Adapter Start must be less than IP-Adapter End.");
                         }

--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
@@ -1054,15 +1054,13 @@ public class WorkflowGeneratorSteps
                         {
                             index = 0;
                         }
-                        string sortOrder = g.UserInput.Get(T2IParamTypes.SegmentationSortOrder, "default");
-                        bool reverseOrder = g.UserInput.Get(T2IParamTypes.ReverseSegmentationOrder, false);
+                        string sortOrder = g.UserInput.Get(T2IParamTypes.SegmentationSortOrder, "left-right");
                         segmentNode = g.CreateNode("SwarmYoloDetection", new JObject()
                         {
                             ["image"] = g.FinalImageOut,
                             ["model_name"] = fullname,
                             ["index"] = index,
                             ["sort_order"] = sortOrder,
-                            ["reverse_order"] = reverseOrder
                         });
                     }
                     else

--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
@@ -384,7 +384,7 @@ public class WorkflowGeneratorSteps
                         });
                         g.FinalNegativePrompt = [zeroed, 0];
                     }
-                    if (!g.UserInput.TryGet(T2IParamTypes.Model, out T2IModel model) || model.ModelClass is null || 
+                    if (!g.UserInput.TryGet(T2IParamTypes.Model, out T2IModel model) || model.ModelClass is null ||
                         (model.ModelClass.CompatClass != "stable-diffusion-xl-v1"/* && model.ModelClass.CompatClass != "stable-diffusion-v3-medium"*/))
                     {
                         throw new SwarmUserErrorException($"Model type must be SDXL for ReVision (currently is {model?.ModelClass?.Name ?? "Unknown"}). Set ReVision Strength to 0 if you just want IP-Adapter.");
@@ -576,7 +576,7 @@ public class WorkflowGeneratorSteps
                         }
                         double ipAdapterStart = g.UserInput.Get(ComfyUIBackendExtension.IPAdapterStart, 0.0);
                         double ipAdapterEnd = g.UserInput.Get(ComfyUIBackendExtension.IPAdapterEnd, 1.0);
-                        if (ipAdapterStart >= ipAdapterEnd) 
+                        if (ipAdapterStart >= ipAdapterEnd)
                         {
                             throw new SwarmUserErrorException($"IP-Adapter Start must be less than IP-Adapter End.");
                         }
@@ -1064,7 +1064,6 @@ public class WorkflowGeneratorSteps
                             ["sort_order"] = sortOrder,
                             ["reverse_order"] = reverseOrder
                         });
-
                     }
                     else
                     {

--- a/src/Text2Image/T2IParamTypes.cs
+++ b/src/Text2Image/T2IParamTypes.cs
@@ -628,11 +628,8 @@ public class T2IParamTypes
         SaveSegmentMask = Register<bool>(new("Save Segment Mask", "If checked, any usage of '<segment:>' syntax in prompts will save the generated mask in output.",
             "false", IgnoreIf: "false", Group: GroupRegionalPrompting, OrderPriority: 3
             ));
-        SegmentationSortOrder = Register<string>(new("Segmentation Sort Order", "How to sort segments when using '<segment:yolo->' syntax.\nleft-right, top-bottom, largest-smallest, or by-name.\nBy-name requires a pre-processing step to remap segment IDs to a consistent order.",
-            "default", Toggleable: true, IgnoreIf: "default", GetValues: _ => ["left-right", "top-bottom", "largest-smallest", "default"], Group: GroupRegionalPrompting, OrderPriority: 4
-            ));
-        ReverseSegmentationOrder = Register<bool>(new("Reverse Segmentation Order", "If checked, reverses the order of segments when using '<segment:yolo->' syntax.\nOnly applies if 'Segmentation Sort Order' is enabled. When enabled, 'left-right' becomes right-left, 'top-bottom' becomes bottom-top, and 'largest-smallest' becomes smallest-largest.",
-            "false", IgnoreIf: "false", Group: GroupRegionalPrompting, OrderPriority: 5
+        SegmentationSortOrder = Register<string>(new("Segmentation Sort Order", "How to sort segments when using '<segment:yolo->' syntax.\nleft-right, top-bottom, bottom-top, largest-smallest, or smallest-largest.\nYou can also use indexes to specify a segment in the given order.\nExmaple: <segment:yolo-face_yolov9c.pt-2> when largest-smallest, will select the second largest face segment.",
+            "left-right", Toggleable: true, IgnoreIf: "left-right", GetValues: _ => ["left-right", "right-left", "top-bottom", "bottom-top", "largest-smallest", "smallest-largest"], Group: GroupRegionalPrompting, OrderPriority: 4
             ));
         SegmentMaskBlur = Register<int>(new("Segment Mask Blur", "Amount of blur to apply to the segment mask before using it.\nThis is for '<segment:>' syntax usage.\nDefaults to 10.",
             "10", Min: 0, Max: 64, Group: GroupRegionalPrompting, Examples: ["0", "4", "8", "16"], Toggleable: true, OrderPriority: 4

--- a/src/Text2Image/T2IParamTypes.cs
+++ b/src/Text2Image/T2IParamTypes.cs
@@ -91,7 +91,7 @@ public enum ParamViewType
 /// <param name="Subtype">The sub-type of the type - for models, this might be eg "Stable-Diffusion".</param>
 /// <param name="ID">The raw ID of this parameter (will be set when registering).</param>
 /// <param name="SharpType">The C# datatype.</param>
-/// 
+///
 public record class T2IParamType(string Name, string Description, string Default, double Min = 0, double Max = 0, double Step = 1, double ViewMin = 0, double ViewMax = 0,
     Func<string, string, string> Clean = null, Func<Session, List<string>> GetValues = null, string[] Examples = null, Func<List<string>, List<string>> ParseList = null, bool ValidateValues = true,
     bool VisibleNormally = true, bool IsAdvanced = false, string FeatureFlag = null, string Permission = null, bool Toggleable = false, double OrderPriority = 10, T2IParamGroup Group = null, string IgnoreIf = null,
@@ -628,14 +628,14 @@ public class T2IParamTypes
         SaveSegmentMask = Register<bool>(new("Save Segment Mask", "If checked, any usage of '<segment:>' syntax in prompts will save the generated mask in output.",
             "false", IgnoreIf: "false", Group: GroupRegionalPrompting, OrderPriority: 3
             ));
-        SegmentationSortOrder = Register<string>(new("Segmentation Sort Order", "How to sort segments when using '<segment:yolo->' syntax.\nleft-right, top-bottom, bottom-top, largest-smallest, or smallest-largest.\nYou can also use indexes to specify a segment in the given order.\nExmaple: <segment:yolo-face_yolov9c.pt-2> when largest-smallest, will select the second largest face segment.",
-            "left-right", Toggleable: true, IgnoreIf: "left-right", GetValues: _ => ["left-right", "right-left", "top-bottom", "bottom-top", "largest-smallest", "smallest-largest"], Group: GroupRegionalPrompting, OrderPriority: 4
-            ));
         SegmentMaskBlur = Register<int>(new("Segment Mask Blur", "Amount of blur to apply to the segment mask before using it.\nThis is for '<segment:>' syntax usage.\nDefaults to 10.",
             "10", Min: 0, Max: 64, Group: GroupRegionalPrompting, Examples: ["0", "4", "8", "16"], Toggleable: true, OrderPriority: 4
             ));
         SegmentMaskGrow = Register<int>(new("Segment Mask Grow", "Number of pixels of grow the segment mask by.\nThis is for '<segment:>' syntax usage.\nDefaults to 16.",
             "16", Min: 0, Max: 512, Group: GroupRegionalPrompting, Examples: ["0", "4", "8", "16", "32"], Toggleable: true, OrderPriority: 5
+            ));
+        SegmentationSortOrder = Register<string>(new("Segmentation Sort Order", "How to sort segments when using '<segment:yolo->' syntax.\nleft-right, right-left, top-bottom, bottom-top, largest-smallest, or smallest-largest.\nYou can also use an index to specify a segment in the given order.\nExmaple: <segment:yolo-face_yolov9c.pt-2> when largest-smallest, will select the second largest face segment.",
+            "left-right", Toggleable: true, IgnoreIf: "left-right", GetValues: _ => ["left-right", "right-left", "top-bottom", "bottom-top", "largest-smallest", "smallest-largest"], Group: GroupRegionalPrompting, OrderPriority: 5.5
             ));
         SegmentThresholdMax = Register<double>(new("Segment Threshold Max", "Maximum mask match value of a segment before clamping.\nLower values force more of the mask to be counted as maximum masking.\nToo-low values may include unwanted areas of the image.\nHigher values may soften the mask.",
             "1", Min: 0.01, Max: 1, Step: 0.05, Toggleable: true, ViewType: ParamViewType.SLIDER, Group: GroupRegionalPrompting, OrderPriority: 6

--- a/src/Text2Image/T2IParamTypes.cs
+++ b/src/Text2Image/T2IParamTypes.cs
@@ -279,7 +279,7 @@ public class T2IParamTypes
         return update;
     }
 
-    public static T2IRegisteredParam<string> Prompt, NegativePrompt, AspectRatio, BackendType, RefinerMethod, FreeUApplyTo, FreeUVersion, PersonalNote, VideoFormat, VideoResolution, UnsamplerPrompt, ImageFormat, MaskBehavior, RawResolution, SeamlessTileable, SD3TextEncs, BitDepth, Webhooks;
+    public static T2IRegisteredParam<string> Prompt, NegativePrompt, AspectRatio, BackendType, RefinerMethod, FreeUApplyTo, FreeUVersion, PersonalNote, VideoFormat, VideoResolution, UnsamplerPrompt, ImageFormat, MaskBehavior, RawResolution, SeamlessTileable, SD3TextEncs, BitDepth, Webhooks, SegmentationSortOrder;
     public static T2IRegisteredParam<int> Images, Steps, Width, Height, BatchSize, ExactBackendID, VAETileSize, ClipStopAtLayer, VideoFrames, VideoMotionBucket, VideoFPS, VideoSteps, RefinerSteps, CascadeLatentCompression, MaskShrinkGrow, MaskBlur, MaskGrow, SegmentMaskBlur, SegmentMaskGrow;
     public static T2IRegisteredParam<long> Seed, VariationSeed, WildcardSeed;
     public static T2IRegisteredParam<double> CFGScale, VariationSeedStrength, InitImageCreativity, InitImageResetToNorm, RefinerControl, RefinerUpscale, RefinerCFGScale, ReVisionStrength, AltResolutionHeightMult,
@@ -288,7 +288,7 @@ public class T2IParamTypes
     public static T2IRegisteredParam<T2IModel> Model, RefinerModel, VAE, ReVisionModel, RegionalObjectInpaintingModel, SegmentModel, VideoModel, RefinerVAE;
     public static T2IRegisteredParam<List<string>> Loras, LoraWeights, LoraSectionConfinement;
     public static T2IRegisteredParam<List<Image>> PromptImages;
-    public static T2IRegisteredParam<bool> SaveIntermediateImages, DoNotSave, ControlNetPreviewOnly, RevisionZeroPrompt, RemoveBackground, NoSeedIncrement, NoPreviews, VideoBoomerang, ModelSpecificEnhancements, UseInpaintingEncode, MaskCompositeUnthresholded, SaveSegmentMask, InitImageRecompositeMask, UseReferenceOnly, RefinerDoTiling, AutomaticVAE, ZeroNegative;
+    public static T2IRegisteredParam<bool> SaveIntermediateImages, DoNotSave, ControlNetPreviewOnly, RevisionZeroPrompt, RemoveBackground, NoSeedIncrement, NoPreviews, VideoBoomerang, ModelSpecificEnhancements, UseInpaintingEncode, MaskCompositeUnthresholded, SaveSegmentMask, InitImageRecompositeMask, UseReferenceOnly, RefinerDoTiling, AutomaticVAE, ZeroNegative, ReverseSegmentationOrder;
 
     public static T2IParamGroup GroupRevision, GroupCore, GroupVariation, GroupResolution, GroupSampling, GroupInitImage, GroupRefiners,
         GroupAdvancedModelAddons, GroupSwarmInternal, GroupFreeU, GroupRegionalPrompting, GroupAdvancedSampling, GroupVideo;
@@ -627,6 +627,12 @@ public class T2IParamTypes
             ));
         SaveSegmentMask = Register<bool>(new("Save Segment Mask", "If checked, any usage of '<segment:>' syntax in prompts will save the generated mask in output.",
             "false", IgnoreIf: "false", Group: GroupRegionalPrompting, OrderPriority: 3
+            ));
+        SegmentationSortOrder = Register<string>(new("Segmentation Sort Order", "How to sort segments when using '<segment:yolo->' syntax.\nleft-right, top-bottom, largest-smallest, or by-name.\nBy-name requires a pre-processing step to remap segment IDs to a consistent order.",
+            "default", Toggleable: true, IgnoreIf: "default", GetValues: _ => ["left-right", "top-bottom", "largest-smallest", "default"], Group: GroupRegionalPrompting, OrderPriority: 4
+            ));
+        ReverseSegmentationOrder = Register<bool>(new("Reverse Segmentation Order", "If checked, reverses the order of segments when using '<segment:yolo->' syntax.\nOnly applies if 'Segmentation Sort Order' is enabled. When enabled, 'left-right' becomes right-left, 'top-bottom' becomes bottom-top, and 'largest-smallest' becomes smallest-largest.",
+            "false", IgnoreIf: "false", Group: GroupRegionalPrompting, OrderPriority: 5
             ));
         SegmentMaskBlur = Register<int>(new("Segment Mask Blur", "Amount of blur to apply to the segment mask before using it.\nThis is for '<segment:>' syntax usage.\nDefaults to 10.",
             "10", Min: 0, Max: 64, Group: GroupRegionalPrompting, Examples: ["0", "4", "8", "16"], Toggleable: true, OrderPriority: 4


### PR DESCRIPTION
Allow yolo segmentation to sort by left-right, top-bottom, largest-smallest, and reverse that order.
Params added to Regional Segmentation Group