### PR TITLE
Upscale 2x setting and new button for Refine Upscale

### DIFF
--- a/src/Core/Settings.cs
+++ b/src/Core/Settings.cs
@@ -317,6 +317,9 @@ public class Settings : AutoConfiguration
             + "\nThe default is blank, which currently implies 'Use As Init,Edit Image,Star,Reuse Parameters'")]
         public string ButtonsUnderMainImages = "";
 
+        [ConfigComment("The ammount of image creativity used by the Upscale 2x button.")]
+        public double UpscaleCreativity = 0.4;
+
         [ConfigComment("If enabled, batch size will be reset to 1 when parameters are loaded.\nThis can prevent accidents that might thrash your GPU or cause compatibility issues, especially for example when importing a comfy workflow.\nYou can still set the batch size at will in the GUI.")]
         public bool ResetBatchSizeToOne = false;
 

--- a/src/Core/Settings.cs
+++ b/src/Core/Settings.cs
@@ -313,11 +313,11 @@ public class Settings : AutoConfiguration
         public bool AutoSwapImagesIncludesFullView = false;
 
         [ConfigComment("A list of what buttons to include directly under images in the main prompt area of the Generate tab.\nOther buttons will be moved into the 'More' dropdown.\nThis should be a comma separated list."
-            + "\nThe following options are available: \"Use As Init\", \"Edit Image\", \"Upscale 2x\", \"Star\", \"Reuse Parameters\", \"Open In Folder\", \"Delete\", \"View In History\""
+            + "\nThe following options are available: \"Use As Init\", \"Edit Image\", \"Upscale 2x\", \"Star\", \"Reuse Parameters\", \"Open In Folder\", \"Delete\", \"View In History\", \"Refine Image\""
             + "\nThe default is blank, which currently implies 'Use As Init,Edit Image,Star,Reuse Parameters'")]
         public string ButtonsUnderMainImages = "";
 
-        [ConfigComment("The ammount of image creativity used by the Upscale 2x button.")]
+        [ConfigComment("The amount of image creativity used by the Upscale 2x button.")]
         public double UpscaleCreativity = 0.4;
 
         [ConfigComment("If enabled, batch size will be reset to 1 when parameters are loaded.\nThis can prevent accidents that might thrash your GPU or cause compatibility issues, especially for example when importing a comfy workflow.\nYou can still set the batch size at will in the GUI.")]

--- a/src/wwwroot/js/genpage/main.js
+++ b/src/wwwroot/js/genpage/main.js
@@ -700,9 +700,25 @@ function setCurrentImage(src, metadata = '', batchId = '', previewGrow = false, 
                 'width': width * 2,
                 'height': height * 2
             };
-            mainGenHandler.doGenerate(input_overrides, { 'initimagecreativity': 0.4 });
+            let upscaleCreativity = parseFloat(getUserSetting('UpscaleCreativity', '0.4'));
+            mainGenHandler.doGenerate(input_overrides, { 'initimagecreativity': upscaleCreativity });
         }));
     }, '', 'Runs an instant generation with this image as the input and scale doubled');
+    includeButton('Refine Image', () => {
+        toDataURL(img.src, (url => {
+            let input_overrides = {
+                'images': 1,
+            };
+            let toggler = getRequiredElementById('input_group_content_refineupscale_toggle');
+            toggler.checked = true;
+            triggerChangeFor(toggler);
+            reuseLastParamVal('input_seed');
+            mainGenHandler.doGenerate(input_overrides);
+            toggler.checked = false;
+            triggerChangeFor(toggler);
+            setSeedToRandom('input_seed');
+        }));
+    }, '', 'Runs an instant generation with Refine / Upscale turned on');
     let metaParsed = { is_starred: false };
     if (metadata) {
         try {


### PR DESCRIPTION
Currently the Upscale 2x button is hardcoded for a 0.4 InitImageCreativity. This adds a setting to the User Settings to change the value the button uses.

Added a new button "Refine Image" that generates the existing image with the current "Refine / Upscale" settings using the same seed.
Essentially the same as clicking the "Reuse Seed" button and enabling the "Refine / Upscale" toggle, generating the image, then turning the refine toggle back off and resetting the seed to random.

It seems the recommended way to upscale is by using the "Refiner / Upscale" section, so it made sense for it to have it's own button.

Original feature request (submitted by myself)
#122 