### PR TITLE
Image history browser auto refresh

### DIFF
--- a/src/Core/Settings.cs
+++ b/src/Core/Settings.cs
@@ -366,6 +366,9 @@ public class Settings : AutoConfiguration
         [ConfigComment("If true, the Image History view will cache small preview thumbnails of images.\nThis should make things run faster. You can turn it off if you don't want that.")]
         public bool ImageHistoryUsePreviews = true;
 
+        [ConfigComment("If true, will refresh Image History Browser after every new image generation.\nWARNING: This may cause heavy resource usage depending on your system and how many images exist.")]
+        public bool ImageHistoryAutoRefresh = false;
+
         [ConfigComment("Delay, in seconds, betweeen Generate Forever updates.\nIf the delay hits and a generation is still waiting, it will be skipped.\nDefault is 0.1 seconds.")]
         public double GenerateForeverDelay = 0.1;
 

--- a/src/wwwroot/js/genpage/generatehandler.js
+++ b/src/wwwroot/js/genpage/generatehandler.js
@@ -142,6 +142,9 @@ class GenerateHandler {
                         discardable[data.batch_index] = images[data.batch_index];
                         delete images[data.batch_index];
                     }
+                    if (getUserSetting('ImageHistoryAutoRefresh')) {
+                        imageHistoryBrowser.update();
+                    }
                 }
                 if (data.gen_progress) {
                     let thisBatchId = `${batch_id}_${data.gen_progress.batch_index}`;


### PR DESCRIPTION
This covers feature request here #175 to add auto refreshing of the image history browser.

Added a setting to enable or disable (disabled by default)

Not sure what the resource hit would be on this if you have a massive image library or when generating large batches, so I added a warning on the setting. 

Not really sure if the generatehandler is the best location for this, but I couldn't find a logical place to stick it without some kind of "do this after generation" function similar to beforeGenRun()