### PR TITLE
Fix for gridgen fullscreen preview failure

### DIFF
--- a/src/BuiltinExtensions/GridGenerator/Assets/swarmui_gridgen_local.js
+++ b/src/BuiltinExtensions/GridGenerator/Assets/swarmui_gridgen_local.js
@@ -39,9 +39,13 @@ function formatMetadata(metadata) {
             }
         }
     };
-    appendObject(data.sui_image_params);
-    if ('sui_extra_data' in data) {
-        appendObject(data.sui_extra_data);
-    }
+	if (metadata) {
+		if ('sui_image_params' in metadata) {
+			appendObject(metadata.sui_image_params);
+		}
+		if ('sui_extra_data' in metadata) {
+			appendObject(metadata.sui_extra_data);
+		}
+	}
     return result;
 }

--- a/src/BuiltinExtensions/GridGenerator/Assets/swarmui_gridgen_local.js
+++ b/src/BuiltinExtensions/GridGenerator/Assets/swarmui_gridgen_local.js
@@ -39,13 +39,13 @@ function formatMetadata(metadata) {
             }
         }
     };
-	if (metadata) {
-		if ('sui_image_params' in metadata) {
-			appendObject(metadata.sui_image_params);
-		}
-		if ('sui_extra_data' in metadata) {
-			appendObject(metadata.sui_extra_data);
-		}
-	}
+    if (metadata) {
+        if ('sui_image_params' in metadata) {
+            appendObject(metadata.sui_image_params);
+        }
+        if ('sui_extra_data' in metadata) {
+            appendObject(metadata.sui_extra_data);
+        }
+    }
     return result;
 }


### PR DESCRIPTION
It appears the object 'data' does not exist. Perhaps 'metadata' was what was needed?

In any case, full screen previews were broken, this seems to fix it.

The code is a little more testy test test, but I can reduce it back to just changing the object name to metadata if you want.

B