### PR TITLE
Scale the mask to match the scaled image when using mask shrink with flux fill

### DIFF
--- a/src/BuiltinExtensions/ComfyUIBackend/ExtraNodes/SwarmComfyCommon/SwarmMasks.py
+++ b/src/BuiltinExtensions/ComfyUIBackend/ExtraNodes/SwarmComfyCommon/SwarmMasks.py
@@ -268,7 +268,7 @@ class SwarmMaskScaleForMP:
     CATEGORY = "SwarmUI/masks"
     RETURN_TYPES = ("MASK",)
     FUNCTION = "scale"
-    DESCRIPTION = "Scales an mask to a target width and height, while keeping the aspect ratio."
+    DESCRIPTION = "Scales a mask to a target width and height, while keeping the aspect ratio."
 
     def scale(self, mask, width, height, can_shrink):
         mpTarget = width * height
@@ -280,8 +280,9 @@ class SwarmMaskScaleForMP:
             return (mask,)
         newWid = int(round(oldWidth * scale / 64) * 64)
         newHei = int(round(oldHeight * scale / 64) * 64)
-        mask = mask.reshape((-1, 1, mask.shape[-2], mask.shape[-1]))
-        s = comfy.utils.common_upscale(mask, newWid, newHei, "bilinear", "disabled")
+        # This is SwarmImageScaleForMP except we insert/remove C instead of moving it.
+        samples = mask.reshape((-1, 1, mask.shape[-2], mask.shape[-1]))
+        s = comfy.utils.common_upscale(samples, newWid, newHei, "bilinear", "disabled")
         s = s.reshape((-1, s.shape[-2], s.shape[-1]))
         return (s,)
 

--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
@@ -935,8 +935,8 @@ public class WorkflowGeneratorSteps
         }, -5);
         JArray doMaskShrinkApply(WorkflowGenerator g, JArray imgIn)
         {
-            (string boundsNode, string croppedMask, string masked, string scaledImage) = g.MaskShrunkInfo;
-            g.MaskShrunkInfo = new(null, null, null, null);
+            (string boundsNode, string croppedMask, string masked, string scaledImage, string scaledMask) = g.MaskShrunkInfo;
+            g.MaskShrunkInfo = new(null, null, null, null, null);
             if (boundsNode is not null)
             {
                 imgIn = g.RecompositeCropped(boundsNode, [croppedMask, 0], g.FinalInputImage, imgIn);
@@ -1160,7 +1160,7 @@ public class WorkflowGeneratorSteps
                         });
                         g.CreateImageSaveNode([imageNode, 0], g.GetStableDynamicID(50000, 0));
                     }
-                    (string boundsNode, string croppedMask, string masked, string scaledImage) = g.CreateImageMaskCrop([segmentNode, 0], g.FinalImageOut, 8, vae, g.FinalLoadedModel, thresholdMax: g.UserInput.Get(T2IParamTypes.SegmentThresholdMax, 1));
+                    (string boundsNode, string croppedMask, string masked, string scaledImage, string scaledMask) = g.CreateImageMaskCrop([segmentNode, 0], g.FinalImageOut, 8, vae, g.FinalLoadedModel, thresholdMax: g.UserInput.Get(T2IParamTypes.SegmentThresholdMax, 1));
                     g.EnableDifferential();
                     (model, clip) = g.LoadLorasForConfinement(part.ContextID, model, clip);
                     JArray prompt = g.CreateConditioning(part.Prompt, clip, t2iModel, true);


### PR DESCRIPTION
To fully fix https://github.com/mcmonkeyprojects/SwarmUI/issues/439, I think the mask also needs to be scaled before passing into the conditioning function.

I wasn't able to find an existing scaled copy of the mask, or an equivalent to SwarmImageScaleForMP that works on masks, so there's some repeated code here. There may be a better way of reusing SwarmImageScaleForMP or work that's already been done scaling the image.