### PR TITLE
Import rembg locally to prevent slow imports

### DIFF
--- a/src/BuiltinExtensions/ComfyUIBackend/ExtraNodes/SwarmComfyExtra/SwarmRemBg.py
+++ b/src/BuiltinExtensions/ComfyUIBackend/ExtraNodes/SwarmComfyExtra/SwarmRemBg.py
@@ -1,7 +1,6 @@
 from PIL import Image
 import numpy as np
 import torch
-from rembg import remove
 
 class SwarmRemBg:
     @classmethod
@@ -17,6 +16,8 @@ class SwarmRemBg:
     FUNCTION = "rem"
 
     def rem(self, images):
+        from rembg import remove
+
         output = []
         masks = []
         for image in images:


### PR DESCRIPTION
Sometimes, for some reason, importing rembg can add like 40s to the startup time for ComfyUI. Let's put that load in the actual function, at least until I can fork and fix rembg.

This is more or less identical to the fix I suggested for comfy_mtb:

https://github.com/melMass/comfy_mtb/pull/216