### PR TITLE
FEAT: support more than one output image per input image

### DIFF
--- a/src/BuiltinExtensions/ImageBatchTool/ImageBatchToolExtension.cs
+++ b/src/BuiltinExtensions/ImageBatchTool/ImageBatchToolExtension.cs
@@ -115,10 +115,6 @@ public class ImageBatchToolExtension : Extension
         {
             string fname = file.Replace('\\', '/').AfterLast('/');
             int imageIndex = batchId++;
-            // the following two variables are used to handle when one input file
-            // produces multiple output images.In that case the first image is output
-            // as normal "output_dir/preExt.ext" but any images after that will be of the
-            // form "output_dir/preExt_lastFileCount.ext" 
             string lastFilePreExt = "";
             int outputCountForInput = 0;
             removeDoneTasks();
@@ -203,7 +199,6 @@ public class ImageBatchToolExtension : Extension
                     ext = properExt;
                 }
                 string outputFilePrefix = $"{preExt}";
-                // if this is the first output image for an input image initialize
                 if (outputFilePrefix != lastFilePreExt)
                 {
                   lastFilePreExt = $"{preExt}";

--- a/src/BuiltinExtensions/ImageBatchTool/ImageBatchToolExtension.cs
+++ b/src/BuiltinExtensions/ImageBatchTool/ImageBatchToolExtension.cs
@@ -18,6 +18,18 @@ public class ImageBatchToolExtension : Extension
 {
     public static PermInfo PermUseImageBatchTool = Permissions.Register(new("imagebatcher_use_image_batcher", "[Image Batch Tool] Use Image Batcher", "If true, the user may use the Image Batcher tool. Only makes sense for localhost users.", PermissionDefault.ADMINS, Permissions.GroupUser));
 
+    //   the following two statics are used to handle when one input file
+    //   produces multiple output images.In that case the first image is output
+    //   as normal "output_dir/preExt.ext" but any images after that will be of the
+    //   form "output_dir/preExt_lastFileCount.ext" 
+
+    // the preext of the last file written out
+    public static string lastFilePreExt;
+
+    // the count of how many files have been written, set after the first output file
+    // for a given input file incremented for all after that for a given input file
+    public static int lastFileCount;
+
     public override void OnPreInit()
     {
         ScriptFiles.Add("Assets/image_batcher.js");
@@ -60,6 +72,7 @@ public class ImageBatchToolExtension : Extension
             await socket.SendJson(new JObject() { ["error"] = "Image batch needs to supply the images to at least one parameter." }, API.WebsocketTimeout);
             return null;
         }
+        lastFilePreExt = ""; // initialize to empty when starting a batch
         Directory.CreateDirectory(output_folder);
         await API.RunWebsocketHandlerCallWS(GenBatchRun_Internal, session, (rawInput, input_folder, output_folder, init_image, revision, controlnet, imageFiles, resMode), socket);
         Logs.Info("Image Batcher completed successfully");
@@ -196,7 +209,19 @@ public class ImageBatchToolExtension : Extension
                 {
                     ext = properExt;
                 }
-                File.WriteAllBytes($"{output_folder}/{preExt}.{ext}", image.Img.ImageData);
+                // if this is the first output image for an input image initialize
+                string outputFilePrefix = $"{preExt}";
+                if (outputFilePrefix != lastFilePreExt)
+                {
+                  lastFileCount = 1;
+                  lastFilePreExt = $"{preExt}";
+                }
+                else // second or later output image so increment
+                {
+                  outputFilePrefix = $"{preExt}_{lastFileCount}";
+                  lastFileCount++;
+                }
+                File.WriteAllBytes($"{output_folder}/{outputFilePrefix}.{ext}", image.Img.ImageData);
                 string img = session.GetImageB64(image.Img);
                 output(new JObject() { ["image"] = img, ["batch_index"] = $"{imageIndex}", ["metadata"] = string.IsNullOrWhiteSpace(metadata) ? null : metadata });
                 WebhookManager.SendEveryGenWebhook(param, img);


### PR DESCRIPTION
For the image batch extension, this change makes it so that when a workflow produces more than one output image for an input image, the output images after the first will be appended with a _1 _2 etc.  For example:

input -> output
File1.png -> File1.png, File1_1.png, File1_2.png   // for three generated images
File2.png -> File2.png   // only one output
File3.png -> File3.png, File3_1.png  // two generated

Addresses Issue https://github.com/mcmonkeyprojects/SwarmUI/issues/494
