### PR TITLE
Generate forever with variation seed

### DIFF
--- a/src/wwwroot/js/genpage/main.js
+++ b/src/wwwroot/js/genpage/main.js
@@ -1034,7 +1034,9 @@ function doGenForeverOnce(minQueueSize) {
         return;
     }
     let allParams = getGenInput();
-    if (!('seed' in allParams) || allParams['seed'] != -1) {
+    const seed = 'seed' in allParams ? allParams['seed'] : -1;
+    const variation = 'variationseed' in allParams ? allParams['variationseed'] : null;
+    if (seed != -1 && variation != -1) {
         if (lastGenForeverParams && JSON.stringify(lastGenForeverParams) == JSON.stringify(allParams)) {
             return;
         }


### PR DESCRIPTION
When generating forever, UI checks that the seed is not set to something other than -1, as it would be unnecessary to generate the same image over and over again.

However, the user can set the variation seed and it should keep generating images if the variation seed is set to random.

If variation filter bar switch isn't checked, variation would equal null, so it works as expected.