### PR TITLE
Fix for some gen params not correctly reset to default state when preset modal is initialized

### DIFF
--- a/src/wwwroot/js/genpage/presets.js
+++ b/src/wwwroot/js/genpage/presets.js
@@ -30,7 +30,7 @@ function clearPresetView() {
     let enableImage = getRequiredElementById('new_preset_enable_image');
     enableImage.checked = false;
     enableImage.disabled = true;
-    for (let type of getPresetTypes(`input`)) {
+    for (let type of getPresetTypes('preset_input')) {
         try {
             let elem = getRequiredElementById('input_' + type.id);
             let presetElem = getRequiredElementById('preset_input_' + type.id);


### PR DESCRIPTION
When the Create/Edit Preset modal is opened, `clearPresetView` loops over gen parameters to set them to the appropriate default states.  It was doing this via `getPresetTypes('input')` which loops over enabled Input controls (as in, those rendered in the left sidebar's Inputs pane).  But we actually want to loop over enabled Preset Input controls (as in, those rendered within the Create/Edit Preset modal).

**To reproduce:**
- Create a preset that affects a `toggleable: true` generation parameter, such as "Segment Mask Blur" under Advanced Options.  Save the preset.
- Create a new preset. Note that the "Segment Mask Blur" parameter retained its checked state from the previously created preset, so the new preset will inherit that value unintentionally unless user clears that toggle manually.

Rubber ducking the bug to myself: https://discord.com/channels/1243166023859961988/1243185862234210389/1339799328755290146

Note that there's been a few recently resolved preset-saving/loading-related bugs (#535 - 3d92e62e10d9f175bc1e03e4798439de4eb578d0, #563 - 661ef7237303f05cef0aef8572bd9805f0e44b45) so I'm slightly wary about reintroducing a regression, but after testing this a bit it seems to work as expected and I can't trigger other issues.