### PR TITLE
Reverse order of images in animated preview

### DIFF
--- a/src/BuiltinExtensions/ComfyUIBackend/ExtraNodes/SwarmComfyCommon/SwarmKSampler.py
+++ b/src/BuiltinExtensions/ComfyUIBackend/ExtraNodes/SwarmComfyCommon/SwarmKSampler.py
@@ -86,6 +86,7 @@ def make_swarm_sampler_callback(steps, device, model, previews):
                 for i in range(x0.shape[0]):
                     preview_img = previewer.decode_latent_to_preview_image("JPEG", x0[i:i+1])
                     images.append(preview_img[1])
+                images.reverse()
                 swarm_send_animated_preview(0, images)
             elif previews == "default":
                 for i in range(x0.shape[0]):


### PR DESCRIPTION
This needs a sanity check, but this fixes the order of frames in the image-to-video animated preview for hunyuan (skyreels) videos playing from last-frame to first-frame for me.  This is especially noticeable with a 0-creativity initial image set, as we end on our initial picture.

If this needs more specific logic (linux-only? hunyuan/skyreels-only?), or is otherwise "working as intended", feel free to reject.