### PR TITLE
Replace `FreneticUtilities.FreneticExtensions.XFast` methods

### DIFF
--- a/src/Accounts/User.cs
+++ b/src/Accounts/User.cs
@@ -92,7 +92,7 @@ public class User
     {
         lock (SessionHandlerSource.DBLock)
         {
-            return SessionHandlerSource.GenericData.FindById($"{UserID}///${dataname}///{name.ToLowerFast()}")?.Data;
+            return SessionHandlerSource.GenericData.FindById($"{UserID}///${dataname}///{name.ToLower()}")?.Data;
         }
     }
 
@@ -129,7 +129,7 @@ public class User
             {
                 return;
             }
-            SessionHandler.GenericDataStore dataStore = new() { ID = $"{UserID}///${dataname}///{name.ToLowerFast()}", Data = data };
+            SessionHandler.GenericDataStore dataStore = new() { ID = $"{UserID}///${dataname}///{name.ToLower()}", Data = data };
             SessionHandlerSource.GenericData.Upsert(dataStore.ID, dataStore);
         }
     }
@@ -139,7 +139,7 @@ public class User
     {
         lock (SessionHandlerSource.DBLock)
         {
-            return SessionHandlerSource.GenericData.Delete($"{UserID}///${dataname}///{name.ToLowerFast()}");
+            return SessionHandlerSource.GenericData.Delete($"{UserID}///${dataname}///{name.ToLower()}");
         }
     }
 
@@ -148,7 +148,7 @@ public class User
     {
         lock (SessionHandlerSource.DBLock)
         {
-            return SessionHandlerSource.T2IPresets.FindById($"{UserID}///{name.ToLowerFast()}");
+            return SessionHandlerSource.T2IPresets.FindById($"{UserID}///{name.ToLower()}");
         }
     }
 
@@ -187,7 +187,7 @@ public class User
             {
                 return;
             }
-            preset.ID = $"{UserID}///{preset.Title.ToLowerFast()}";
+            preset.ID = $"{UserID}///{preset.Title.ToLower()}";
             SessionHandlerSource.T2IPresets.Upsert(preset.ID, preset);
             if (!Data.Presets.Contains(preset.ID))
             {
@@ -202,7 +202,7 @@ public class User
     {
         lock (SessionHandlerSource.DBLock)
         {
-            string id = $"{UserID}///{name.ToLowerFast()}";
+            string id = $"{UserID}///{name.ToLower()}";
             if (Data.Presets.Remove(id))
             {
                 SessionHandlerSource.T2IPresets.Delete(id);
@@ -415,7 +415,7 @@ public class User
     /// <summary>Returns true if the user is allowed to view a model with a given name, or false if it is restricted.</summary>
     public bool IsAllowedModel(string name)
     {
-        if (name.ToLowerFast() == "(none)")
+        if (name.ToLower() == "(none)")
         {
             return true;
         }

--- a/src/Backends/BackendHandler.cs
+++ b/src/Backends/BackendHandler.cs
@@ -200,7 +200,7 @@ public class BackendHandler
             return new JObject()
             {
                 ["name"] = f.Name,
-                ["type"] = typeName.ToLowerFast(),
+                ["type"] = typeName.ToLower(),
                 ["description"] = f.Field.GetCustomAttribute<AutoConfiguration.ConfigComment>()?.Comments?.ToString() ?? "",
                 ["placeholder"] = f.Field.GetCustomAttribute<SuggestionPlaceholder>()?.Text ?? "",
                 ["is_secret"] = f.Field.GetCustomAttribute<ValueIsSecretAttribute>() is not null,
@@ -644,7 +644,7 @@ public class BackendHandler
     /// <summary>Tells all backends to load a given model. Returns true if any backends have loaded it, or false if not.</summary>
     public async Task<bool> LoadModelOnAll(T2IModel model, Func<T2IBackendData, bool> filter = null)
     {
-        if (model.Name.ToLowerFast() == "(none)")
+        if (model.Name.ToLower() == "(none)")
         {
             return true;
         }
@@ -1216,7 +1216,7 @@ public class BackendHandler
                                 Thread.Sleep(100);
                             }
                             Utilities.CleanRAM();
-                            if (highestPressure.Model.Name.ToLowerFast() == "(none)")
+                            if (highestPressure.Model.Name.ToLower() == "(none)")
                             {
                                 availableBackend.Backend.CurrentModelName = highestPressure.Model.Name;
                             }

--- a/src/Backends/NetworkBackendUtils.cs
+++ b/src/Backends/NetworkBackendUtils.cs
@@ -548,7 +548,7 @@ public static class NetworkBackendUtils
             bool keepShowing = false;
             while ((line = process.StandardError.ReadLine()) != null)
             {
-                string lineLow = line.ToLowerFast();
+                string lineLow = line.ToLower();
                 if (lineLow.StartsWith("traceback (") || lineLow.Contains("error: "))
                 {
                     keepShowing = true;

--- a/src/BuiltinExtensions/ComfyUIBackend/ComfyUIAPIAbstractBackend.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/ComfyUIAPIAbstractBackend.cs
@@ -1,14 +1,10 @@
-﻿
-using FreneticUtilities.FreneticDataSyntax;
-using FreneticUtilities.FreneticExtensions;
+﻿using FreneticUtilities.FreneticExtensions;
 using FreneticUtilities.FreneticToolkit;
 using Newtonsoft.Json.Linq;
 using SwarmUI.Backends;
 using SwarmUI.Core;
 using SwarmUI.Text2Image;
 using SwarmUI.Utils;
-using System;
-using System.IO;
 using System.Net.Http;
 using System.Net.WebSockets;
 using System.Web;
@@ -489,7 +485,7 @@ public abstract class ComfyUIAPIAbstractBackend : AbstractT2IBackend
                 if (msg[0].ToString() == "execution_error" && (msg[1] as JObject).TryGetValue("exception_message", out JToken actualMessage))
                 {
                     string note = "";
-                    string cleanCheckMessage = $"{actualMessage}".ToLowerFast().Replace('\\', '/').Trim();
+                    string cleanCheckMessage = $"{actualMessage}".ToLower().Replace('\\', '/').Trim();
                     while (cleanCheckMessage.Contains("//"))
                     {
                         cleanCheckMessage = cleanCheckMessage.Replace("//", "/");

--- a/src/BuiltinExtensions/ComfyUIBackend/ComfyUIBackendExtension.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/ComfyUIBackendExtension.cs
@@ -233,7 +233,7 @@ public class ComfyUIBackendExtension : Extension
                 {
                     foreach (T2IParamDataType possible in Enum.GetValues<T2IParamDataType>())
                     {
-                        string typeId = possible.ToString().ToLowerFast();
+                        string typeId = possible.ToString().ToLower();
                         if (nameNoPrefix.StartsWith(typeId))
                         {
                             nameNoPrefix = nameNoPrefix.After(typeId);

--- a/src/BuiltinExtensions/ComfyUIBackend/ComfyUISelfStartBackend.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/ComfyUISelfStartBackend.cs
@@ -1,5 +1,4 @@
-﻿
-using FreneticUtilities.FreneticDataSyntax;
+﻿using FreneticUtilities.FreneticDataSyntax;
 using FreneticUtilities.FreneticExtensions;
 using FreneticUtilities.FreneticToolkit;
 using SwarmUI.Backends;
@@ -192,7 +191,7 @@ public class ComfyUISelfStartBackend : ComfyUIAPIAbstractBackend
                     string fullPath;
                     if (IsWindows)
                     {
-                        fullPath = Utilities.CombinePathWithAbsolute(root, opt.ToLowerFast());
+                        fullPath = Utilities.CombinePathWithAbsolute(root, opt.ToLower());
                     }
                     else
                     {
@@ -304,7 +303,7 @@ public class ComfyUISelfStartBackend : ComfyUIAPIAbstractBackend
         }
         AddLoadStatus("Will track node repo load task...");
         List<Task> tasks = [Task.Run(EnsureNodeRepos)];
-        string autoUpd = settings.AutoUpdate.ToLowerFast();
+        string autoUpd = settings.AutoUpdate.ToLower();
         if ((autoUpd == "true" || autoUpd == "aggressive") && !string.IsNullOrWhiteSpace(settings.StartScript))
         {
             AddLoadStatus("Will track comfy git pull auto-update task...");

--- a/src/BuiltinExtensions/ComfyUIBackend/ComfyUIWebAPI.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/ComfyUIWebAPI.cs
@@ -180,7 +180,7 @@ public static class ComfyUIWebAPI
                 Logs.Warning($"User {session.User.UserID} tried to install feature '{features}' but have no comfy self-start backends.");
                 return new JObject() { ["error"] = $"Cannot install Comfy features as this Swarm instance has no running ComfyUI Self-Start backends currently." };
             }
-            features = features.ToLowerFast();
+            features = features.ToLower();
             List<InstallableFeatures.ComfyInstallableFeature> installMe = [];
             foreach (string feature in features.Split(',').Select(f => f.Trim()))
             {

--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGenerator.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGenerator.cs
@@ -611,7 +611,7 @@ public class WorkflowGenerator
         string helper = $"modelloader_{model.Name}_{type}";
         if (NodeHelpers.TryGetValue(helper, out string alreadyLoaded))
         {
-            string[] parts = alreadyLoaded.SplitFast(':');
+            string[] parts = alreadyLoaded.Split(':');
             LoadingModel = [parts[0], int.Parse(parts[1])];
             LoadingClip = parts[2].Length == 0 ? null : [parts[2], int.Parse(parts[3])];
             LoadingVAE = parts[4].Length == 0 ? null : [parts[4], int.Parse(parts[5])];
@@ -1318,7 +1318,7 @@ public class WorkflowGenerator
             {
                 ["sampler_name"] = UserInput.Get(ComfyUIBackendExtension.SamplerParam, defsampler ?? DefaultSampler)
             });
-            string scheduler = UserInput.Get(ComfyUIBackendExtension.SchedulerParam, defscheduler ?? DefaultScheduler).ToLowerFast();
+            string scheduler = UserInput.Get(ComfyUIBackendExtension.SchedulerParam, defscheduler ?? DefaultScheduler).ToLower();
             double denoise = 1;// 1.0 - (startStep / (double)steps); // NOTE: Edit model breaks on denoise<1
             JArray schedulerNode;
             if (scheduler == "turbo")
@@ -1889,7 +1889,7 @@ public class WorkflowGenerator
                 string svdVae = UserInput.SourceSession?.User?.Settings?.VAEs?.DefaultSVDVAE;
                 if (string.IsNullOrWhiteSpace(svdVae))
                 {
-                    svdVae = Program.T2IModelSets["VAE"].Models.Keys.FirstOrDefault(m => m.ToLowerFast().Contains("sdxl"));
+                    svdVae = Program.T2IModelSets["VAE"].Models.Keys.FirstOrDefault(m => m.ToLower().Contains("sdxl"));
                 }
                 if (string.IsNullOrWhiteSpace(svdVae))
                 {

--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
@@ -86,7 +86,7 @@ public class WorkflowGeneratorSteps
                 {
                     vaeName = g.UserInput.SourceSession?.User?.Settings.VAEs.DefaultSDv1VAE;
                 }
-                if (!string.IsNullOrWhiteSpace(vaeName) && vaeName.ToLowerFast() != "none")
+                if (!string.IsNullOrWhiteSpace(vaeName) && vaeName.ToLower() != "none")
                 {
                     string match = T2IParamTypes.GetBestModelInList(vaeName, Program.T2IModelSets["VAE"].ListModelNamesFor(g.UserInput.SourceSession));
                     if (match is not null)
@@ -607,7 +607,7 @@ public class WorkflowGeneratorSteps
                     }
                     if (g.Features.Contains("cubiqipadapterunified"))
                     {
-                        string presetLow = ipAdapter.ToLowerFast();
+                        string presetLow = ipAdapter.ToLower();
                         bool isXl = g.CurrentCompatClass() == "stable-diffusion-xl-v1";
                         void requireIPAdapterModel(string name, string url, string hash)
                         {
@@ -861,7 +861,7 @@ public class WorkflowGeneratorSteps
                     {
                         preprocessor = "none";
                         string wantedPreproc = controlModel?.Metadata?.Preprocessor;
-                        string cnName = $"{controlModel?.Name}{controlModel?.RawFilePath.Replace('\\', '/').AfterLast('/')}".ToLowerFast();
+                        string cnName = $"{controlModel?.Name}{controlModel?.RawFilePath.Replace('\\', '/').AfterLast('/')}".ToLower();
                         if (string.IsNullOrWhiteSpace(wantedPreproc))
                         {
                             if (cnName.Contains("canny")) { wantedPreproc = "canny"; }
@@ -879,7 +879,7 @@ public class WorkflowGeneratorSteps
                             string[] procs = [.. ComfyUIBackendExtension.ControlNetPreprocessors.Keys];
                             bool getBestFor(string phrase)
                             {
-                                string result = procs.FirstOrDefault(m => m.ToLowerFast().Contains(phrase.ToLowerFast()));
+                                string result = procs.FirstOrDefault(m => m.ToLower().Contains(phrase.ToLower()));
                                 if (result is not null)
                                 {
                                     preprocessor = result;
@@ -921,7 +921,7 @@ public class WorkflowGeneratorSteps
                             }
                         }
                     }
-                    if (preprocessor.ToLowerFast() != "none")
+                    if (preprocessor.ToLower() != "none")
                     {
                         JArray preprocActual = g.CreatePreprocessor(preprocessor, imageNodeActual);
                         g.NodeHelpers["controlnet_preprocessor"] = $"{preprocActual[0]}";
@@ -1434,7 +1434,7 @@ public class WorkflowGeneratorSteps
                 int? videoFps = g.UserInput.TryGet(T2IParamTypes.VideoFPS, out int fpsRaw) ? fpsRaw : null;
                 double? videoCfg = g.UserInput.TryGet(T2IParamTypes.VideoCFG, out double cfgRaw) ? cfgRaw : null;
                 int steps = g.UserInput.Get(T2IParamTypes.VideoSteps, 20);
-                string format = g.UserInput.Get(T2IParamTypes.VideoFormat, "webp").ToLowerFast();
+                string format = g.UserInput.Get(T2IParamTypes.VideoFormat, "webp").ToLower();
                 string resFormat = g.UserInput.Get(T2IParamTypes.VideoResolution, "Model Preferred");
                 long seed = g.UserInput.Get(T2IParamTypes.Seed) + 42;
                 string prompt = g.UserInput.Get(T2IParamTypes.Prompt, "");
@@ -1546,7 +1546,7 @@ public class WorkflowGeneratorSteps
                 int steps = g.UserInput.Get(T2IParamTypes.Steps, 20);
                 long seed = g.UserInput.Get(T2IParamTypes.Seed) + 600;
                 int? videoFps = g.UserInput.TryGet(T2IParamTypes.VideoFPS, out int fpsRaw) ? fpsRaw : null;
-                string format = g.UserInput.Get(T2IParamTypes.VideoExtendFormat, "webp").ToLowerFast();
+                string format = g.UserInput.Get(T2IParamTypes.VideoExtendFormat, "webp").ToLower();
                 int frameExtendOverlap = g.UserInput.Get(T2IParamTypes.VideoExtendFrameOverlap, 9);
                 bool saveIntermediate = g.UserInput.Get(T2IParamTypes.SaveIntermediateImages, false);
                 T2IModel extendModel = g.UserInput.Get(T2IParamTypes.VideoExtendModel, null) ?? throw new SwarmUserErrorException("You have an '<extend:' block in your prompt, but you don't have a 'Video Extend Model' selected.");

--- a/src/BuiltinExtensions/GridGenerator/GridGenCore.cs
+++ b/src/BuiltinExtensions/GridGenerator/GridGenCore.cs
@@ -46,7 +46,7 @@ public partial class GridGenCore
 
     public static string CleanID(string id)
     {
-        return CleanIDMatcher.TrimToMatches(id.ToLowerFast().Trim());
+        return CleanIDMatcher.TrimToMatches(id.ToLower().Trim());
     }
 
     public static List<string> ExpandNumericListRanges(List<string> inList, Type numType)
@@ -201,11 +201,11 @@ public partial class GridGenCore
                     {
                         valStr = T2IParamTypes.ValidateParam(Mode, valStr, grid.InitialParams.SourceSession);
                     }
-                    string key = ValidKeysMatcher.TrimToMatches(valStr.Replace('.', '_').ToLowerFast());
+                    string key = ValidKeysMatcher.TrimToMatches(valStr.Replace('.', '_').ToLower());
                     if (key.Length > 15)
                     {
                         // Long keys might be model names or similar, so trim them to a probably better name
-                        key = ValidKeysMatcher.TrimToMatches(valStr.AfterLast('/').ToLowerFast().Replace(".safetensors", ""));
+                        key = ValidKeysMatcher.TrimToMatches(valStr.AfterLast('/').ToLower().Replace(".safetensors", ""));
                         if (key.Length > 15)
                         {
                             key = key[0..15];
@@ -561,8 +561,8 @@ public partial class GridGenCore
                 {
                     JObject jVal = new()
                     {
-                        ["key"] = val.Key.ToLowerFast(),
-                        ["path"] = val.Key.ToLowerFast(),
+                        ["key"] = val.Key.ToLower(),
+                        ["path"] = val.Key.ToLower(),
                         ["title"] = val.Title,
                         ["description"] = val.Description ?? "",
                         ["show"] = val.Show
@@ -582,7 +582,7 @@ public partial class GridGenCore
 
         public string RadioButtonHtml(string name, string id, string descrip, string label)
         {
-            return $"<input type=\"radio\" class=\"btn-check\" name=\"{name}\" id=\"{id.ToLowerFast()}\" autocomplete=\"off\" checked=\"\"><label class=\"btn btn-outline-primary\" for=\"{id.ToLowerFast()}\" title=\"{descrip}\">{EscapeHtml(label)}</label>\n";
+            return $"<input type=\"radio\" class=\"btn-check\" name=\"{name}\" id=\"{id.ToLower()}\" autocomplete=\"off\" checked=\"\"><label class=\"btn btn-outline-primary\" for=\"{id.ToLower()}\" title=\"{descrip}\">{EscapeHtml(label)}</label>\n";
         }
 
         public string AxisBar(string label, string content)
@@ -734,7 +734,7 @@ public partial class GridGenCore
         int axisIndex = 0;
         foreach (JToken axis in axes)
         {
-            string id = axis["mode"].ToString().ToLowerFast().Trim();
+            string id = axis["mode"].ToString().ToLower().Trim();
             if (id != "")
             {
                 try

--- a/src/BuiltinExtensions/GridGenerator/GridGeneratorExtension.cs
+++ b/src/BuiltinExtensions/GridGenerator/GridGeneratorExtension.cs
@@ -147,9 +147,9 @@ public class GridGeneratorExtension : Extension
             if (thisParams.TryGet(PresetsParameter, out string presets))
             {
                 List<T2IPreset> userPresets = data.Session.User.GetAllPresets();
-                foreach (string preset in presets.ToLowerFast().Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                foreach (string preset in presets.ToLower().Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
                 {
-                    T2IPreset match = userPresets.FirstOrDefault(p => p.Title.ToLowerFast() == preset);
+                    T2IPreset match = userPresets.FirstOrDefault(p => p.Title.ToLower() == preset);
                     if (match is null)
                     {
                         setError($"Could not find preset '{preset}'");

--- a/src/Core/Program.cs
+++ b/src/Core/Program.cs
@@ -309,7 +309,7 @@ public class Program
             Thread.Sleep(500);
             try
             {
-                switch (LaunchMode.Trim().ToLowerFast())
+                switch (LaunchMode.Trim().ToLower())
                 {
                     case "web":
                         Logs.Init("Launch web browser...");
@@ -597,7 +597,7 @@ public class Program
     public static void ApplyCommandLineSettings()
     {
         ReapplySettings();
-        string environment = GetCommandLineFlag("environment", "production").ToLowerFast() switch
+        string environment = GetCommandLineFlag("environment", "production").ToLower() switch
         {
             "dev" or "development" => "Development",
             "prod" or "production" => "Production",
@@ -732,7 +732,7 @@ public class Program
     /// <summary>Gets the command line flag for the given key as a boolean.</summary>
     public static bool GetCommandLineFlagAsBool(string key, bool def)
     {
-        return GetCommandLineFlag(key, def.ToString()).ToLowerFast() switch
+        return GetCommandLineFlag(key, def.ToString()).ToLower() switch
         {
             "true" or "yes" or "1" => true,
             "false" or "no" or "0" => false,

--- a/src/Core/WebServer.cs
+++ b/src/Core/WebServer.cs
@@ -118,10 +118,10 @@ public class WebServer
         {
             if (context.Request.Headers.Host.Any() && context.Request.Headers.Origin.Any())
             {
-                string host = context.Request.Headers.Host[0].ToLowerFast();
-                string origin = context.Request.Headers.Origin[0].ToLowerFast();
+                string host = context.Request.Headers.Host[0].ToLower();
+                string origin = context.Request.Headers.Origin[0].ToLower();
                 Uri uri = new(origin);
-                string originMain = uri.Authority.ToLowerFast();
+                string originMain = uri.Authority.ToLower();
                 if (host != originMain)
                 {
                     // TODO: Instate this check fully only after comfy's version is stable.
@@ -157,7 +157,7 @@ public class WebServer
                     {
                         remoteIp = addr.MapToIPv4().ToString();
                     }
-                    if (!Program.ServerSettings.Network.AuthBypassIPs.SplitFast(',').Contains(remoteIp))
+                    if (!Program.ServerSettings.Network.AuthBypassIPs.Split(',').Contains(remoteIp))
                     {
                         if (string.IsNullOrWhiteSpace(authHeader))
                         {
@@ -197,8 +197,8 @@ public class WebServer
         timer.Check("[Web] static files");
         WebApp.Use(async (context, next) =>
         {
-            string referrer = (context.Request.Headers.Referer.FirstOrDefault() ?? "").After("://").After('/').ToLowerFast();
-            string path = context.Request.Path.Value.ToLowerFast();
+            string referrer = (context.Request.Headers.Referer.FirstOrDefault() ?? "").After("://").After('/').ToLower();
+            string path = context.Request.Path.Value.ToLower();
             if (referrer.StartsWith("comfybackenddirect/") && !path.StartsWith("/comfybackenddirect/"))
             {
                 Logs.Debug($"ComfyBackendDirect call was misrouted, rerouting to '{context.Request.Path}'");
@@ -251,7 +251,7 @@ public class WebServer
                 {
                     return;
                 }
-                string path = context.Request.Path.Value.ToLowerFast();
+                string path = context.Request.Path.Value.ToLower();
                 if (!path.StartsWith("/error/"))
                 {
                     try

--- a/src/Text2Image/T2IEngine.cs
+++ b/src/Text2Image/T2IEngine.cs
@@ -1,12 +1,9 @@
-﻿using FreneticUtilities.FreneticExtensions;
-using Newtonsoft.Json.Linq;
+﻿using Newtonsoft.Json.Linq;
 using SwarmUI.Accounts;
 using SwarmUI.Backends;
 using SwarmUI.Core;
 using SwarmUI.Utils;
 using SwarmUI.WebAPI;
-using System.Diagnostics;
-using System.IO;
 
 namespace SwarmUI.Text2Image
 {
@@ -61,12 +58,12 @@ namespace SwarmUI.Text2Image
         {
             string type = user_input.Get(T2IParamTypes.BackendType, "any");
             bool requireId = user_input.TryGet(T2IParamTypes.ExactBackendID, out int reqId);
-            string typeLow = type.ToLowerFast();
+            string typeLow = type.ToLower();
             return backend =>
             {
-                if (typeLow != "any" && typeLow != backend.Backend.HandlerTypeData.ID.ToLowerFast())
+                if (typeLow != "any" && typeLow != backend.Backend.HandlerTypeData.ID.ToLower())
                 {
-                    Logs.Verbose($"Filter out backend {backend.ID} as the Type is specified as {typeLow}, but the backend type is {backend.Backend.HandlerTypeData.ID.ToLowerFast()}");
+                    Logs.Verbose($"Filter out backend {backend.ID} as the Type is specified as {typeLow}, but the backend type is {backend.Backend.HandlerTypeData.ID.ToLower()}");
                     user_input.RefusalReasons.Add($"Specific backend type requested in advanced parameters did not match");
                     return false;
                 }
@@ -90,7 +87,7 @@ namespace SwarmUI.Text2Image
                 {
                     bool requireModel(T2IRegisteredParam<T2IModel> param, string type)
                     {
-                        if (user_input.TryGet(param, out T2IModel model) && model.Name.ToLowerFast() != "(none)" && backend.Backend.Models.TryGetValue(type, out List<string> models) && !models.Contains(model.Name) && !models.Contains(model.Name + ".safetensors"))
+                        if (user_input.TryGet(param, out T2IModel model) && model.Name.ToLower() != "(none)" && backend.Backend.Models.TryGetValue(type, out List<string> models) && !models.Contains(model.Name) && !models.Contains(model.Name + ".safetensors"))
                         {
                             Logs.Verbose($"Filter out backend {backend.ID} as the request requires {type} model {model.Name}, but the backend does not have that model");
                             user_input.RefusalReasons.Add($"Request requires model '{model.Name}' but the backend does not have that model");

--- a/src/Text2Image/T2IModel.cs
+++ b/src/Text2Image/T2IModel.cs
@@ -61,8 +61,8 @@ public class T2IModel(T2IModelHandler handler, string folderPath, string filePat
     {
         get
         {
-            string cleaned = OriginatingFolderPath.Replace('\\', '/').TrimEnd('/').ToLowerFast();
-            return cleaned.EndsWithFast("/unet") || cleaned.EndsWithFast("/diffusion_models"); // Hacky but it works for now
+            string cleaned = OriginatingFolderPath.Replace('\\', '/').TrimEnd('/').ToLower();
+            return cleaned.EndsWith("/unet") || cleaned.EndsWith("/diffusion_models"); // Hacky but it works for now
         }
     }
 

--- a/src/Text2Image/T2IParamInput.cs
+++ b/src/Text2Image/T2IParamInput.cs
@@ -242,7 +242,7 @@ public class T2IParamInput
         string separator = " ";
         if (preData is not null)
         {
-            if (preData.EndsWithFast(','))
+            if (preData.EndsWith(','))
             {
                 separator = ", ";
                 preData = preData[0..^1];
@@ -501,7 +501,7 @@ public class T2IParamInput
         {
             data = context.Parse(data);
             context.Embeds ??= [.. Program.T2IModelSets["Embedding"].ListModelNamesFor(context.Input.SourceSession)];
-            string want = data.ToLowerFast().Replace('\\', '/');
+            string want = data.ToLower().Replace('\\', '/');
             string matched = T2IParamTypes.GetBestModelInList(want, context.Embeds);
             if (matched is null)
             {
@@ -528,7 +528,7 @@ public class T2IParamInput
         PromptTagPostProcessors["lora"] = (data, context) =>
         {
             data = context.Parse(data);
-            string lora = data.ToLowerFast().Replace('\\', '/');
+            string lora = data.ToLower().Replace('\\', '/');
             int colonIndex = lora.IndexOf(':');
             double strength = 1;
             double tencStrength = double.NaN;
@@ -1082,7 +1082,7 @@ public class T2IParamInput
                 {
                     (prefix, preData) = prefix.BeforeLast(']').BeforeAndAfter('[');
                 }
-                prefix = prefix.ToLowerFast();
+                prefix = prefix.ToLower();
                 context.RawCurrentTag = tag;
                 context.PreData = preData;
                 Logs.Verbose($"[Prompt Parsing] Found tag {val}, will fill... prefix = '{prefix}', data = '{data}', predata = '{preData}'");
@@ -1261,7 +1261,7 @@ public class T2IParamInput
         }
         Image imageFor(string val)
         {
-            if (val.StartsWithFast("data:"))
+            if (val.StartsWith("data:"))
             {
                 return Image.FromDataString(val);
             }
@@ -1299,7 +1299,7 @@ public class T2IParamInput
         ValuesInput[param.ID] = obj;
         if (param.FeatureFlag is not null)
         {
-            RequiredFlags.UnionWith(param.FeatureFlag.SplitFast(','));
+            RequiredFlags.UnionWith(param.FeatureFlag.Split(','));
         }
     }
 
@@ -1319,7 +1319,7 @@ public class T2IParamInput
         ValuesInput[param.Type.ID] = val;
         if (param.Type.FeatureFlag is not null)
         {
-            RequiredFlags.UnionWith(param.Type.FeatureFlag.SplitFast(','));
+            RequiredFlags.UnionWith(param.Type.FeatureFlag.Split(','));
         }
     }
     

--- a/src/Text2Image/T2IParamTypes.cs
+++ b/src/Text2Image/T2IParamTypes.cs
@@ -4,7 +4,6 @@ using Newtonsoft.Json.Linq;
 using SwarmUI.Accounts;
 using SwarmUI.Core;
 using SwarmUI.Utils;
-using System.IO;
 
 namespace SwarmUI.Text2Image;
 
@@ -113,7 +112,7 @@ public record class T2IParamType(string Name, string Description, string Default
             ["name"] = Name,
             ["id"] = ID,
             ["description"] = Description,
-            ["type"] = Type.ToString().ToLowerFast(),
+            ["type"] = Type.ToString().ToLower(),
             ["subtype"] = Subtype,
             ["default"] = Default,
             ["min"] = Min,
@@ -133,7 +132,7 @@ public record class T2IParamType(string Name, string Description, string Default
             ["always_retain"] = AlwaysRetain,
             ["do_not_save"] = DoNotSave,
             ["do_not_preview"] = DoNotPreview,
-            ["view_type"] = ViewType.ToString().ToLowerFast(),
+            ["view_type"] = ViewType.ToString().ToLower(),
             ["extra_hidden"] = ExtraHidden,
             ["nonreusable"] = Nonreusable
         };
@@ -243,19 +242,19 @@ public class T2IParamTypes
     /// <summary>Type-name cleaner.</summary>
     public static string CleanTypeName(string name)
     {
-        return CleanTypeNameMatcher.TrimToMatches(name.ToLowerFast().Trim());
+        return CleanTypeNameMatcher.TrimToMatches(name.ToLower().Trim());
     }
 
     /// <summary>Generic user-input name cleaner.</summary>
     public static string CleanNameGeneric(string name)
     {
-        return name.ToLowerFast().Replace(" ", "").Replace("[", "").Replace("]", "").Trim();
+        return name.ToLower().Replace(" ", "").Replace("[", "").Replace("]", "").Trim();
     }
 
     /// <summary>Strips ".safetensors" from the end of model name for cleanliness.</summary>
     public static string CleanModelName(string name)
     {
-        if (name.EndsWithFast(".safetensors"))
+        if (name.EndsWith(".safetensors"))
         {
             name = name.BeforeLast(".safetensors");
         }
@@ -265,7 +264,7 @@ public class T2IParamTypes
     /// <summary>Strips ".safetensors" from the end of model name comma-separated-lists for cleanliness.</summary>
     public static string CleanModelNameList(string names)
     {
-        return names.SplitFast(',').Select(s => CleanModelName(s.Trim())).JoinString(",");
+        return names.Split(',').Select(s => CleanModelName(s.Trim())).JoinString(",");
     }
 
     /// <summary>Applies a string edit, with support for "{value}" notation.</summary>
@@ -274,7 +273,7 @@ public class T2IParamTypes
         if (update.Contains("{value}"))
         {
             prior ??= "";
-            string low = prior.ToLowerFast();
+            string low = prior.ToLower();
             int end = new int[] { low.IndexOf("<segment:"), low.IndexOf("<object:"), low.IndexOf("<region:") }.Where(i => i != -1).Order().FirstOrDefault(-1);
             if (end != -1)
             {
@@ -320,7 +319,7 @@ public class T2IParamTypes
     /// <summary>Cleans and sorts a model listing for output in a user-exposed parameter.</summary>
     public static List<string> CleanModelList(IEnumerable<string> models)
     {
-        return [.. models.Select(CleanModelName).OrderBy(s => s.ToLowerFast())];
+        return [.. models.Select(CleanModelName).OrderBy(s => s.ToLower())];
     }
 
     /// <summary>(Called by <see cref="Program"/> during startup) registers all default parameter types.</summary>
@@ -852,7 +851,7 @@ public class T2IParamTypes
                 }
                 return valDouble.ToString();
             case T2IParamDataType.BOOLEAN:
-                val = val.ToLowerFast();
+                val = val.ToLower();
                 if (val != "true" && val != "false")
                 {
                     throw new SwarmUserErrorException($"Invalid boolean value for param {type.Name} - '{origVal}' - must be exactly 'true' or 'false'");

--- a/src/Utils/AutoCompleteListHelper.cs
+++ b/src/Utils/AutoCompleteListHelper.cs
@@ -57,14 +57,14 @@ public class AutoCompleteListHelper
         }
         string[] result = AutoCompletionLists.GetOrCreate(name, () =>
         {
-            return [.. File.ReadAllText($"{FolderPath}/{name}").Replace('\r', '\n').SplitFast('\n').Select(s => s.Trim()).Where(s => !string.IsNullOrWhiteSpace(s) && !s.StartsWithFast('#'))];
+            return [.. File.ReadAllText($"{FolderPath}/{name}").Replace('\r', '\n').Split('\n').Select(s => s.Trim()).Where(s => !string.IsNullOrWhiteSpace(s) && !s.StartsWith('#'))];
         });
         bool doSpace = spaceMode == "Spaces";
         bool doUnderscore = spaceMode == "Underscores";
         result = [.. result];
         for (int i = 0; i < result.Length; i++)
         {
-            string[] parts = result[i].SplitFast(',');
+            string[] parts = result[i].Split(',');
             if (parts.Length == 2 && long.TryParse(parts[1], out _))
             {
                 parts = [parts[0], "0", parts[1], ""];

--- a/src/Utils/Image.cs
+++ b/src/Utils/Image.cs
@@ -1,6 +1,4 @@
-﻿namespace SwarmUI.Utils;
-
-using SixLabors.ImageSharp;
+﻿using SixLabors.ImageSharp;
 using System.IO;
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using ISImage = SixLabors.ImageSharp.Image;
@@ -10,7 +8,8 @@ using FreneticUtilities.FreneticExtensions;
 using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.Formats.Webp;
 using SixLabors.ImageSharp.Formats.Jpeg;
-using SixLabors.ImageSharp.PixelFormats;
+
+namespace SwarmUI.Utils;
 
 /// <summary>Helper to represent an image file cleanly and quickly.</summary>
 public class Image
@@ -213,7 +212,7 @@ public class Image
         try
         {
             ISImage img = ToIS;
-            string pngMetadata = img.Metadata?.GetPngMetadata()?.TextData?.FirstOrDefault(t => t.Keyword.ToLowerFast() == "parameters").Value;
+            string pngMetadata = img.Metadata?.GetPngMetadata()?.TextData?.FirstOrDefault(t => t.Keyword.ToLower() == "parameters").Value;
             if (pngMetadata is not null)
             {
                 return pngMetadata;

--- a/src/Utils/ProxyHandler.cs
+++ b/src/Utils/ProxyHandler.cs
@@ -80,7 +80,7 @@ public class PublicProxyHandler
                     Logs.Debug($"{Name} says: {line}");
                     if (Name == "Ngrok")
                     {
-                        string[] parts = line.SplitFast(' ');
+                        string[] parts = line.Split(' ');
                         // t=time lvl=info msg="started tunnel" obj=tunnels name=command_line addr=(internal_address) url=(this-is-what-we-want)
                         if (parts.Length >= 8)
                         {

--- a/src/Utils/PythonLaunchHelper.cs
+++ b/src/Utils/PythonLaunchHelper.cs
@@ -41,7 +41,7 @@ public class PythonLaunchHelper
         {
             // Strip python but be a little cautious about it
             string[] paths = Environment.GetEnvironmentVariable("PATH").Split(';').Where(p => !p.Contains("Python3") && !p.Contains("Programs\\Python") && !p.Contains("Python\\Python")).ToArray();
-            string[] python = paths.Where(p => p.ToLowerFast().Contains("python")).ToArray();
+            string[] python = paths.Where(p => p.ToLower().Contains("python")).ToArray();
             if (python.Any())
             {
                 Logs.Debug($"Python paths left: {python.JoinString("; ")}");

--- a/src/Utils/Utilities.cs
+++ b/src/Utils/Utilities.cs
@@ -57,7 +57,7 @@ public static class Utilities
         DateTimeOffset now = DateTimeOffset.Now;
         if (!string.IsNullOrWhiteSpace(limitHours))
         {
-            string[] hours = [.. limitHours.SplitFast(',').Select(h => h.Trim())];
+            string[] hours = [.. limitHours.Split(',').Select(h => h.Trim())];
             if (hours.Length > 0 && !hours.Contains($"{now.Hour}") && !hours.Contains($"0{now.Hour}"))
             {
                 return;
@@ -65,8 +65,8 @@ public static class Utilities
         }
         if (!string.IsNullOrWhiteSpace(limitDays))
         {
-            string[] days = [.. limitDays.SplitFast(',').Select(d => d.Trim().ToLowerFast())];
-            if (days.Length > 0 && !days.Contains($"{(int)now.DayOfWeek}") && !days.Contains($"{now.DayOfWeek.ToString().ToLowerFast()}"))
+            string[] days = [.. limitDays.Split(',').Select(d => d.Trim().ToLower())];
+            if (days.Length > 0 && !days.Contains($"{(int)now.DayOfWeek}") && !days.Contains($"{now.DayOfWeek.ToString().ToLower()}"))
             {
                 return;
             }
@@ -163,7 +163,7 @@ public static class Utilities
         string[] parts = name.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
         for (int i = 0; i < parts.Length; i++)
         {
-            if (ReservedFilenames.Contains(parts[i].ToLowerFast()))
+            if (ReservedFilenames.Contains(parts[i].ToLower()))
             {
                 parts[i] = $"{parts[i]}_";
             }
@@ -707,9 +707,9 @@ public static class Utilities
                             }
                             sha256.TransformFinalBlock([], 0, 0);
                             byte[] hash = sha256.Hash;
-                            string hashStr = Convert.ToHexString(hash).ToLowerFast();
+                            string hashStr = Convert.ToHexString(hash).ToLower();
                             Logs.Verbose($"Raw file hash for {altUrl} is {hashStr}");
-                            if (verifyHash is not null && hashStr != verifyHash.ToLowerFast())
+                            if (verifyHash is not null && hashStr != verifyHash.ToLower())
                             {
                                 removeFile();
                                 throw new SwarmReadableErrorException($"Download {altUrl} failed: expected SHA256 hash {verifyHash} but got {hashStr}.");

--- a/src/WebAPI/API.cs
+++ b/src/WebAPI/API.cs
@@ -20,7 +20,7 @@ public class API
     /// <summary>Register a new API call handler.</summary>
     public static void RegisterAPICall(APICall call)
     {
-        APIHandlers.Add(call.Name.ToLowerFast(), call);
+        APIHandlers.Add(call.Name.ToLower(), call);
     }
 
     /// <summary>Register a new API call handler.</summary>
@@ -82,7 +82,7 @@ public class API
                 context.Response.Redirect("/Error/BasicAPI");
                 return;
             }
-            string path = context.Request.Path.ToString().ToLowerFast().After("/api/");
+            string path = context.Request.Path.ToString().ToLower().After("/api/");
             if (path != "getnewsession")
             {
                 if (!input.TryGetValue("session_id", out JToken session_id))
@@ -239,12 +239,12 @@ public class API
             if (call.IsWebSocket)
             {
                 docText.Append($"## WebSocket Route /API/{call.Name}\n\n");
-                toc.Append($"- WebSocket Route [{call.Name}](#websocket-route-api{call.Name.ToLowerFast()})\n");
+                toc.Append($"- WebSocket Route [{call.Name}](#websocket-route-api{call.Name.ToLower()})\n");
             }
             else
             {
                 docText.Append($"## HTTP Route /API/{call.Name}\n\n");
-                toc.Append($"- HTTP Route [{call.Name}](#http-route-api{call.Name.ToLowerFast()})\n");
+                toc.Append($"- HTTP Route [{call.Name}](#http-route-api{call.Name.ToLower()})\n");
             }
             APIDescriptionAttribute methodDesc = call.Original.GetCustomAttribute<APIDescriptionAttribute>();
             string perm = call.Permission is null ? "(MISSING)" : $"`{call.Permission.ID}` - `{call.Permission.DisplayName}` in group `{call.Permission.Group.DisplayName}`";

--- a/src/WebAPI/AdminAPI.cs
+++ b/src/WebAPI/AdminAPI.cs
@@ -75,7 +75,7 @@ public static class AdminAPI
             }
             output[key] = new JObject()
             {
-                ["type"] = typeName.ToLowerFast(),
+                ["type"] = typeName.ToLower(),
                 ["name"] = data.Name,
                 ["value"] = isSecret ? "\t<secret>" : JToken.FromObject(val is List<string> list ? list.JoinString(" || ") : val),
                 ["description"] = data.Field.GetCustomAttribute<AutoConfiguration.ConfigComment>()?.Comments ?? "",
@@ -614,7 +614,7 @@ public static class AdminAPI
         [API.APIParameter("Initial password for the new user.")] string password,
         [API.APIParameter("Initial role for the new user.")] string role)
     {
-        string cleaned = Utilities.StrictFilenameClean(name).ToLowerFast().Replace('/', '_');
+        string cleaned = Utilities.StrictFilenameClean(name).ToLower().Replace('/', '_');
         lock (Program.Sessions.DBLock)
         {
             User existing = Program.Sessions.GetUser(cleaned, false);
@@ -699,7 +699,7 @@ public static class AdminAPI
     public static async Task<JObject> AdminAddRole(Session session,
         [API.APIParameter("The name of the new role.")] string name)
     {
-        string cleaned = Utilities.StrictFilenameClean(name).ToLowerFast().Replace('/', '_');
+        string cleaned = Utilities.StrictFilenameClean(name).ToLower().Replace('/', '_');
         lock (Program.Sessions.DBLock)
         {
             Role newRole = new(name);

--- a/src/WebAPI/BackendAPI.cs
+++ b/src/WebAPI/BackendAPI.cs
@@ -57,7 +57,7 @@ public class BackendAPI
         JObject data = new()
         {
             ["type"] = backend.Backend.HandlerTypeData.ID,
-            ["status"] = backend.Backend.Status.ToString().ToLowerFast(),
+            ["status"] = backend.Backend.Status.ToString().ToLower(),
             ["id"] = backend.ID,
             ["settings"] = JToken.FromObject(backend.Backend.SettingsRaw.SaveAllWithoutSecretValues("\t<secret>", "").ToSimple()),
             ["modcount"] = backend.ModCount,

--- a/src/WebAPI/BasicAPIFeatures.cs
+++ b/src/WebAPI/BasicAPIFeatures.cs
@@ -367,7 +367,7 @@ public static class BasicAPIFeatures
                 Logs.Error($"User '{session.User.UserID}' tried to set setting '{key}' of type '{field.Field.FieldType.Name}' to '{val}', but type-conversion failed.");
                 continue;
             }
-            if (key.ToLowerFast() == "password")
+            if (key.ToLower() == "password")
             {
                 if ($"{val}".Length < 8)
                 {

--- a/src/WebAPI/ModelsAPI.cs
+++ b/src/WebAPI/ModelsAPI.cs
@@ -99,7 +99,7 @@ public static class ModelsAPI
                     return card.GetNetObject();
                 }
             }
-            else if (subtype == "Stable-Diffusion" && modelName.ToLowerFast() == "(none)")
+            else if (subtype == "Stable-Diffusion" && modelName.ToLower() == "(none)")
             {
                 return new JObject() { ["model"] = NoneModel.ToNetObject() };
             }
@@ -557,7 +557,7 @@ public static class ModelsAPI
                     Logs.Verbose($"Model download websocket inbound: {data}");
                     if (data.TryGetValue("signal", out JToken signal))
                     {
-                        string cmd = $"{signal}".ToLowerFast();
+                        string cmd = $"{signal}".ToLower();
                         if (cmd == "cancel")
                         {
                             canceller.Cancel();
@@ -641,7 +641,7 @@ public static class ModelsAPI
     [API.APIDescription("Forwards a metadata request, eg to civitai API.", "")]
     public static async Task<JObject> ForwardMetadataRequest(Session session, string url)
     {
-        if (!url.StartsWithFast("https://civitai.com/"))
+        if (!url.StartsWith("https://civitai.com/"))
         {
             return new JObject() { ["error"] = "Invalid URL." };
         }


### PR DESCRIPTION
I've looked into these "Fast" methods, provided by `FreneticUtilities.FreneticExtensions`, for example `ToLowerFast` and I was fairly disappointed to see `Char[]` allocation, while dotnet's implementation uses `Span<char>`.

So I wanted to see if my intuition was wrong by running the following benchmark:
```C#
    [GlobalSetup]
    public void Setup()
    {
        // Generate a huge string (1 million characters)
        hugeString = new string(Enumerable.Repeat("AaBCdf DEshkFGe HIJKcdLMNO gePQRddSTUv SJD VWiyXYZ", 20000)
            .SelectMany(s => s).ToArray());
    }

    [Benchmark]
    public string ToLower() => hugeString.ToLower();
    [Benchmark]
    public string ToLowerFast() => hugeString.ToLowerFast();
    [Benchmark]
    public string[] Split() => hugeString.Split(' ');
    [Benchmark]
    public string[] SplitFast() => hugeString.SplitFast(' ');
```
Which yields the results:

  [Host]     : .NET 8.0.13 (8.0.1325.6609), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.13 (8.0.1325.6609), X64 RyuJIT AVX2


| Method      | Mean       | Error     | StdDev    | Median     | Gen0     | Gen1     | Gen2     | Allocated |
|------------ |-----------:|----------:|----------:|-----------:|---------:|---------:|---------:|----------:|
| ToLower     |   323.7 us |  10.73 us |  31.63 us |   312.3 us | 283.6914 | 283.6914 | 283.6914 |   1.91 MB |
| ToLowerFast | 1,390.3 us |  23.50 us |  20.83 us | 1,387.5 us | 597.6563 | 597.6563 | 597.6563 |   3.81 MB |
| Split       | 6,694.7 us | 120.43 us | 106.76 us | 6,698.2 us | 539.0625 | 531.2500 | 195.3125 |   4.88 MB |
| SplitFast   | 6,889.0 us | 116.52 us | 108.99 us | 6,901.8 us | 546.8750 | 539.0625 | 203.1250 |   4.88 MB |

As you can see, while `Split` didn't show much difference, `ToLowerFast` indeed allocates the huge string twice, while `ToLower`  allocates once as it loops through `Span<char>`, avoiding additional heap allocation.
`ToLower` is $\times 4.3$ faster and allocates half as much. This is fairly noticeable when working with big data scale tokens. 

One can open a followup PR that adds a custom analyzer to warn about `X.Fast` usage.