### PR TITLE
Save sorting & view settings in cookie storage to survive restarts

### DIFF
--- a/src/wwwroot/js/genpage/browsers.js
+++ b/src/wwwroot/js/genpage/browsers.js
@@ -76,7 +76,7 @@ class GenPageBrowserClass {
         this.extraHeader = extraHeader;
         this.navCaller = this.navigate.bind(this);
         this.tree = new BrowserTreePart('', {}, false, true, null, '');
-        this.depth = localStorage.getItem(`browser_${id}_depth`) || defaultDepth;
+        this.depth = localStorage.getItem(`browser_${id}_depth`) || getCookie(`browser_${this.id}_depth`) || defaultDepth;
         this.filter = localStorage.getItem(`browser_${id}_filter`) || '';
         this.folderTreeVerticalSpacing = '0';
         this.splitterMinWidth = 100;
@@ -596,6 +596,7 @@ class GenPageBrowserClass {
             let depthInput = inputArr[0];
             depthInput.addEventListener('change', () => {
                 this.depth = depthInput.value;
+                setCookie(`browser_${this.id}_depth`, this.depth, 90);
                 localStorage.setItem(`browser_${this.id}_depth`, this.depth);
                 this.updateWithoutDup();
             });

--- a/src/wwwroot/js/genpage/browsers.js
+++ b/src/wwwroot/js/genpage/browsers.js
@@ -579,6 +579,7 @@ class GenPageBrowserClass {
             }
             formatSelector.addEventListener('change', () => {
                 this.format = formatSelector.value;
+                setCookie(`${this.id}_format`, this.format, 90);
                 localStorage.setItem(`browser_${this.id}_format`, this.format);
                 this.updateWithoutDup();
             });

--- a/src/wwwroot/js/genpage/models.js
+++ b/src/wwwroot/js/genpage/models.js
@@ -484,8 +484,8 @@ class ModelBrowserWrapper {
             }, 100);
             return;
         }
-        let sortBy = localStorage.getItem(`models_${this.subType}_sort_by`) ?? 'Name';
-        let reverse = localStorage.getItem(`models_${this.subType}_sort_reverse`) == 'true';
+        let sortBy = localStorage.getItem(`models_${this.subType}_sort_by`) ?? getCookie(`models_${this.subType}_sort_by`) ?? 'Name';
+        let reverse = (localStorage.getItem(`models_${this.subType}_sort_reverse`) ?? getCookie(`models_${this.subType}_sort_by`)) == 'true';
         let sortElem = document.getElementById(`models_${this.subType}_sort_by`);
         let sortReverseElem = document.getElementById(`models_${this.subType}_sort_reverse`);
         let fix = null;
@@ -500,10 +500,12 @@ class ModelBrowserWrapper {
                 sortElem.value = sortBy;
                 sortReverseElem.checked = reverse;
                 sortElem.addEventListener('change', () => {
+                    setCookie(`models_${this.subType}_sort_by`, sortElem.value, 90);
                     localStorage.setItem(`models_${this.subType}_sort_by`, sortElem.value);
                     this.browser.update();
                 });
                 sortReverseElem.addEventListener('change', () => {
+                    setCookie(`models_${this.subType}_sort_reverse`, sortReverseElem.checked, 90);
                     localStorage.setItem(`models_${this.subType}_sort_reverse`, sortReverseElem.checked);
                     this.browser.update();
                 });


### PR DESCRIPTION
This preserves the following options in the default 90-day cookie storage:
- format option (Cards, Thumbnail, Lists, etc)
- sort by option
- reverse sort option
- depth

Tested it and it seems to work ok for me.

I see there's a few more options we could save but I'm not sure if they're worth storing. For example `filter`, but this is probably transitory.

----

There's a bit of key path copy-pasta here. Let me know if you want me to refactor this.

Cheers~