### PR TITLE
Optimize JObject Conversion

### DIFF
--- a/src/WebAPI/AdminAPI.cs
+++ b/src/WebAPI/AdminAPI.cs
@@ -241,7 +241,7 @@ public static class AdminAPI
         long lastSeq = Interlocked.Read(ref Logs.LogTracker.LastSequenceID);
         result["last_sequence_id"] = lastSeq;
         JObject messageData = [];
-        List<string> types = [.. raw["types"].Select(v => $"{v}")];
+        string[] types = raw["types"].ToObject<string[]>();
         foreach (string type in types)
         {
             Logs.LogTracker tracker;
@@ -418,7 +418,7 @@ public static class AdminAPI
     public static async Task<JObject> DebugLanguageAdd(Session session,
         [API.APIParameter("\"set\": [ \"word\", ... ]")] JObject raw)
     {
-        LanguagesHelper.TrackSet([.. raw["set"].ToArray().Select(v => $"{v}")]);
+        LanguagesHelper.TrackSet(raw["set"].ToObject<string[]>());
         return new JObject() { ["success"] = true };
     }
 


### PR DESCRIPTION
Given the following example
```csharp
LanguagesHelper.TrackSet([.. raw["set"].ToArray().Select(v => $"{v}")]);
```
Without mentioning the allocations introduced by `ToArray()` and the spread operator, the underlying values are already (likely to be) strings, so the manual `v => "{v}"` conversion introduces a redundant overhead by creating extra intermediate objects.

Using `JValue.ToObject<T>` uses deserialization which uses direct conversion, and makes it a perfect choice here for both performance and error handling. 