### PR TITLE
Treat wan i2v 1.3b like t2v for teacache

### DIFF
--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
@@ -245,7 +245,7 @@ public class WorkflowGeneratorSteps
                     else
                     {
                         string arch = g.CurrentModelClass()?.ID;
-                        if (arch == "wan-2_1-text2video-1_3b")
+                        if (arch == "wan-2_1-text2video-1_3b" || arch == "wan-2_1-image2video-1_3b")
                         {
                             type = "wan2.1_t2v_1.3B";
                         }


### PR DESCRIPTION
This PR fixes a confusing `KeyError: ''` error message when attempting to use wan fun inp 1.3b with teacache, and uses the teacache config for the t2v model, which is cross-compatible enough to work with the 1.3b inp i2v model. It's one line, you can see what it does.

It does so by giving teacache the t2v model variant when either t2v or i2v 1.3b is used.