### PR TITLE
feat: mount custom_nodes and models folders into SwarmUI container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Properties/
 /Output
 /Data
 /Models
+/ComfyUI
 tmp/
 /src/Extensions
 /dlbackend

--- a/launchtools/launch-standard-docker.sh
+++ b/launchtools/launch-standard-docker.sh
@@ -29,6 +29,8 @@ docker run -it \
     -v "$PWD/Models:/SwarmUI/Models" \
     -v "$PWD/Output:/SwarmUI/Output" \
     -v "$PWD/src/BuiltinExtensions/ComfyUIBackend/CustomWorkflows:/SwarmUI/src/BuiltinExtensions/ComfyUIBackend/CustomWorkflows" \
+    -v "$PWD/ComfyUI/custom_nodes:/SwarmUI/dlbackend/ComfyUI/custom_nodes" \
+    -v "$PWD/ComfyUI/models:/SwarmUI/dlbackend/ComfyUI/models" \
     --gpus=all -p 7801:7801 swarmui $POSTARG
 
 if [ $? == 42 ]; then


### PR DESCRIPTION
Added Docker volume mounts to map local ComfyUI folders into the SwarmUI container:
- custom_nodes → /SwarmUI/dlbackend/ComfyUI/custom_nodes
- models → /SwarmUI/dlbackend/ComfyUI/models

This ensures that custom nodes and model files are available inside the container for use by the ComfyUI backend.