### PR TITLE
CSS changes - conditionally reduce padding to stop overflow, and conditionally reduce button size in main area

### DIFF
--- a/src/wwwroot/css/themes/modern.css
+++ b/src/wwwroot/css/themes/modern.css
@@ -46,6 +46,10 @@
     transition: background .2s;
 }
 
+.current-image-buttons .basic-button { @container (max-width:500px) {
+    font-size:75%;
+} }
+
 .nav-tabs, #currentimagecontent, #inputsidebartab_content, #rightsidebarcontent, #t2i_bottom_bar {
     background-color: var(--background-panel);
     background-image: url(imgs/noise.png);
@@ -175,6 +179,10 @@
     padding: 30px;
     transition: padding 0.2s;
 }
+
+#main_inputs_area_wrapper { @container (max-width: 350px) { 
+    padding: 30px 8px;
+} }
 
 #main_inputs_area_wrapper.main_inputs_small {
     padding: 30px 20px;

--- a/src/wwwroot/js/genpage/gentab/layout.js
+++ b/src/wwwroot/js/genpage/gentab/layout.js
@@ -196,7 +196,7 @@ class GenTabLayout {
         }
         this.inputSidebar.style.width = `${barTopLeft}`;
         this.inputSidebar.style.display = this.leftShut ? 'none' : '';
-		this.inputSidebar.style.containerType="inline-size";
+        this.inputSidebar.style.containerType="inline-size";
         this.altRegion.style.width = `calc(100vw - ${barTopLeft} - ${barTopRight} - 10px)`;
         this.mainImageArea.style.width = `calc(100vw - ${barTopLeft})`;
         this.mainImageArea.scrollTop = 0;
@@ -209,7 +209,7 @@ class GenTabLayout {
             this.currentImage.style.width = `calc(${curImgWidth})`;
         }
         this.currentImageWrapbox.style.width = `calc(${curImgWidth})`;
-		this.currentImageWrapbox.style.containerType = "inline-size";
+        this.currentImageWrapbox.style.containerType = "inline-size";
         this.currentImageBatch.style.width = `calc(${barTopRight} - 6px)`;
         if (this.currentImageBatchCore.offsetWidth < 425) {
             this.currentImageBatchCore.classList.add('current_image_batch_core_small');

--- a/src/wwwroot/js/genpage/gentab/layout.js
+++ b/src/wwwroot/js/genpage/gentab/layout.js
@@ -196,6 +196,7 @@ class GenTabLayout {
         }
         this.inputSidebar.style.width = `${barTopLeft}`;
         this.inputSidebar.style.display = this.leftShut ? 'none' : '';
+		this.inputSidebar.style.containerType="inline-size";
         this.altRegion.style.width = `calc(100vw - ${barTopLeft} - ${barTopRight} - 10px)`;
         this.mainImageArea.style.width = `calc(100vw - ${barTopLeft})`;
         this.mainImageArea.scrollTop = 0;
@@ -208,6 +209,7 @@ class GenTabLayout {
             this.currentImage.style.width = `calc(${curImgWidth})`;
         }
         this.currentImageWrapbox.style.width = `calc(${curImgWidth})`;
+		this.currentImageWrapbox.style.containerType = "inline-size";
         this.currentImageBatch.style.width = `calc(${barTopRight} - 6px)`;
         if (this.currentImageBatchCore.offsetWidth < 425) {
             this.currentImageBatchCore.classList.add('current_image_batch_core_small');


### PR DESCRIPTION
For #727

This fixes a CSS overflow on the left side due to too much padding.  A conditional CSS rule is added to shrink the padding down to 8px when the input sidebar is under 350px wide.

There's also a CSS change to shrink the size of the buttons in the main view if the main view is under 500px wide, so they all fit in one row.