### PR TITLE
Update docker-standard-inner.sh - Fix for permissions issue when buil…

### DIFF
--- a/launchtools/docker-standard-inner.sh
+++ b/launchtools/docker-standard-inner.sh
@@ -27,5 +27,10 @@ fi
 # Add a fake home path, because docker defaults it to '/'
 HOME=/SwarmUI/dlbackend/linuxhome
 
+# Add a runtime fix for Models permissions
+if [ -d "/SwarmUI/Models" ]; then
+    chown -R $(id -u):$(id -g) /SwarmUI/Models || true
+fi
+
 # Launch as normal, just ensure launch mode is off and host is global (to expose it out of the container)
 bash /SwarmUI/launch-linux.sh $@ --launch_mode none --host 0.0.0.0


### PR DESCRIPTION
…ding docker

This update is part of a fix for the following permissions issue when building docker

(base) owner@icarus:~/Documents/projects/SwarmUI$ ./launchtools/launch-standard-docker.sh
[+] Building 4.0s (13/13) FINISHED                                                                        docker:default
 => [internal] load build definition from StandardDockerfile.docker                                                 0.0s
 => => transferring dockerfile: 819B                                                                                0.0s
 => [internal] load metadata for mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim                                     0.3s
 => [internal] load .dockerignore                                                                                   0.0s
 => => transferring context: 199B                                                                                   0.0s
 => [1/8] FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim@sha256:1875fc5f4be6211c22c4353aafd6b13279c0175f277fb  0.0s
 => [internal] load build context                                                                                   0.4s
 => => transferring context: 60.11MB                                                                                0.3s
 => CACHED [2/8] RUN apt update                                                                                     0.0s
 => CACHED [3/8] RUN apt install -y git wget build-essential python3.11 python3.11-venv python3.11-dev ffmpeg       0.0s
 => CACHED [4/8] RUN apt install -y libglib2.0-0 libgl1                                                             0.0s
 => [5/8] COPY . ./SwarmUI                                                                                          0.6s
 => [6/8] RUN chown -R 1000:1000 ./SwarmUI                                                                          0.9s
 => [7/8] RUN git config --global --add safe.directory '*'                                                          0.5s
 => [8/8] RUN useradd -u 1000 swarmui                                                                               0.5s
 => exporting to image                                                                                              0.5s
 => => exporting layers                                                                                             0.4s
 => => writing image sha256:a9a5383f3b154dbe9d471db92e1be539cb24408d8d6ad1738fab58c226115261                        0.0s
 => => naming to docker.io/library/swarmui                                                                          0.0s
cat: src/bin/last_build: No such file or directory


WARNING: You did a git pull without building. Will now build for you...

touch: cannot touch './src/bin/must_rebuild': No such file or directory
  Determining projects to restore...
  Restored /SwarmUI/src/SwarmUI.csproj (in 281 ms).
  SwarmUI -> /SwarmUI/src/bin/live_release/SwarmUI.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:05.20
06:49:57.780 [Init] === SwarmUI v0.9.6.0 Starting at 2025-04-25 06:49:57 === 06:49:57.824 [Init] Prepping extension: SwarmUI.Builtin_ScorersExtension.ScorersExtension... 06:49:57.825 [Init] Prepping extension: SwarmUI.Builtin_ImageBatchToolExtension.ImageBatchToolExtension... 06:49:57.825 [Init] Prepping extension: SwarmUI.Builtin_GridGeneratorExtension.GridGeneratorExtension... 06:49:57.826 [Init] Prepping extension: SwarmUI.Builtin_DynamicThresholding.DynamicThresholdingExtension... 06:49:57.826 [Init] Prepping extension: SwarmUI.Builtin_ComfyUIBackend.ComfyUIBackendExtension... 06:49:57.826 [Init] Prepping extension: SwarmUI.Builtin_AutoWebUIExtension.AutoWebUIBackendExtension... 06:49:57.866 [Init] Parsing command line...
06:49:57.867 [Init] Loading settings file...
06:49:57.886 [Init] Re-saving settings file...
06:49:57.907 [Init] Applying command line settings... 06:49:57.932 [Init] SwarmUI was installed 2025-04-25 (0 days ago) with version 0.9.6.0 06:49:57.943 [Init] Current git commit is [37594818: comfy now depends on pydantic], marked as date 2025-04-24 23:05:22 06:49:57.955 [Error] Failed to run event on extension SwarmUI.Builtin_ComfyUIBackend.ComfyUIBackendExtension: System.UnauthorizedAccessException: Access to the path '/SwarmUI/src/BuiltinExtensions/ComfyUIBackend/CustomWorkflows/Examples' is denied.
 ---> System.IO.IOException: Permission denied
   --- End of inner exception stack trace ---
   at System.IO.FileSystem.CreateDirectory(String fullPath, UnixFileMode unixCreateMode)
   at System.IO.Directory.CreateDirectory(String path)
   at SwarmUI.Builtin_ComfyUIBackend.ComfyUIBackendExtension.LoadWorkflowFiles() in /SwarmUI/src/BuiltinExtensions/ComfyUIBackend/ComfyUIBackendExtension.cs:line 281
   at SwarmUI.Builtin_ComfyUIBackend.ComfyUIBackendExtension.OnPreInit() in /SwarmUI/src/BuiltinExtensions/ComfyUIBackend/ComfyUIBackendExtension.cs:line 77
   at SwarmUI.Core.Program.<>c.<Main>b__24_6(Extension e) in /SwarmUI/src/Core/Program.cs:line 251
   at SwarmUI.Core.ExtensionsManager.RunOnAllExtensions(Action`1 action) in /SwarmUI/src/Core/ExtensionsManager.cs:line 141
06:49:57.955 [Init] Prepping options...
Unhandled exception. System.UnauthorizedAccessException: Access to the path '/SwarmUI/Models/Stable-Diffusion' is denied.
 ---> System.IO.IOException: Permission denied
   --- End of inner exception stack trace ---
   at System.IO.FileSystem.CreateDirectory(String fullPath, UnixFileMode unixCreateMode)
   at System.IO.Directory.CreateDirectory(String path)
   at SwarmUI.Core.Program.BuildModelLists() in /SwarmUI/src/Core/Program.cs:line 373
   at SwarmUI.Core.Program.Main(String[] args) in /SwarmUI/src/Core/Program.cs:line 254
/SwarmUI/launch-linux.sh: line 17:   132 Aborted                 (core dumped) ./src/bin/live_release/SwarmUI $@