### PR TITLE
standardize seed controls

### DIFF
--- a/src/Core/Settings.cs
+++ b/src/Core/Settings.cs
@@ -466,7 +466,7 @@ public class Settings : AutoConfiguration
         public string Language = "en";
 
         [ConfigComment("Comma-separated list of parameters to exclude from 'Reuse Parameters'.\nFor example, set 'model' to not copy the model, or 'model,refinermodel,videomodel' to really never copy any models.")]
-        public string ReuseParamExcludeList = "wildcardseed";
+        public string ReuseParamExcludeList = "";
 
         /// <summary>Settings related to audio.</summary>
         public class AudioData : AutoConfiguration

--- a/src/Text2Image/T2IParamInput.cs
+++ b/src/Text2Image/T2IParamInput.cs
@@ -744,7 +744,7 @@ public class T2IParamInput
 
     /// <summary>Dense local time with incrementer.</summary>
     public int RequestRefTime;
-    
+
     /// <summary>If true, special early load has already ran.</summary>
     public bool EarlyLoadDone = false;
 
@@ -1051,7 +1051,7 @@ public class T2IParamInput
         }
         else
         {
-            wildcardSeed = Get(T2IParamTypes.Seed) + Get(T2IParamTypes.VariationSeed, 0) + 17;
+            wildcardSeed = Get(T2IParamTypes.Seed) + Get(T2IParamTypes.VariationSeed, 0);
         }
         if (wildcardSeed > int.MaxValue)
         {
@@ -1360,7 +1360,7 @@ public class T2IParamInput
             RequiredFlags.UnionWith(param.Type.FeatureFlag.SplitFast(','));
         }
     }
-    
+
     /// <summary>Removes a param.</summary>
     public void Remove<T>(T2IRegisteredParam<T> param)
     {

--- a/src/wwwroot/js/genpage/gentab/currentimagehandler.js
+++ b/src/wwwroot/js/genpage/gentab/currentimagehandler.js
@@ -336,6 +336,13 @@ function copy_current_image_params() {
         let elem = document.getElementById(`input_${param.id}`);
         let val = metadata[param.id];
         if (elem && val !== undefined && val !== null && val !== '') {
+            // only reuse a seed parameter if it is not the same as the image gen seed.
+            if (param.id.includes('seed') && param.id !== 'seed') {
+                let mainGenSeed = metadata['seed'];
+                if (typeof mainGenSeed !== 'undefined' && val == mainGenSeed) {
+                    continue;
+                }
+            }
             setDirectParamValue(param, val);
             if (param.group && param.group.toggles) {
                 let toggle = getRequiredElementById(`input_group_content_${param.group.id}_toggle`);
@@ -407,7 +414,7 @@ function shiftToNextImagePreview(next = true, expand = false) {
 
 window.addEventListener('keydown', function(kbevent) {
     let isFullView = imageFullView.isOpen();
-    let isCurImgFocused = document.activeElement && 
+    let isCurImgFocused = document.activeElement &&
         (findParentOfClass(document.activeElement, 'current_image')
         || findParentOfClass(document.activeElement, 'current_image_batch')
         || document.activeElement.tagName == 'BODY');


### PR DESCRIPTION
this pr does 3 things:

1) wildcard seed uses the same seed as the image gen seed if not specified, instead of image gen seed + 17 (why?)

2) the reuse parameters button only reuses seed values if they are not the same as the image gen seed (works fine for extensions too as long as the seed metadata includes "seed").

3) remove the wildcardseed exception from the reuse params button, as it is no longer necessary.

the main reason for this pr is that i found it pretty annoying having to reset tipo seed after every time i reuse params from an image generated with tipo, but i didnt want to exclude it either. and less finnicky wildcard/extension seeds is nice too i think.

but it is a pretty subjective pr, i understand if you dont want it merged for whatever reason.

i have also updated [tipoforswarmui](https://github.com/Hugs288/TipoForSwarmUI) to take advantage of these changes.