### PR TITLE
Fix placeholder image persisting from the wrong model

### DIFF
--- a/src/wwwroot/js/genpage/helpers/generatehandler.js
+++ b/src/wwwroot/js/genpage/helpers/generatehandler.js
@@ -198,8 +198,8 @@ class GenerateHandler {
                     let thisBatchId = `${batch_id}_${data.gen_progress.batch_index}`;
                     if (!(data.gen_progress.batch_index in images)) {
                         let metadataRaw = data.gen_progress.metadata ?? '{}';
-                        let metadataParsed = (() => { try { return JSON.parse(metadataRaw); } catch { return {}; } })();
-                        let batch_div = this.gotImagePreview(data.gen_progress.preview ?? `DOPLACEHOLDER:${metadataParsed.sui_image_params?.model || ''}`, metadataRaw, thisBatchId);
+                        let metadataParsed = JSON.parse(metadataRaw);
+                        let batch_div = this.gotImagePreview(data.gen_progress.preview ?? `DOPLACEHOLDER:${metadataParsed.sui_image_params?.model || actualInput.model || ''}`, metadataRaw, thisBatchId);
                         if (batch_div) {
                             images[data.gen_progress.batch_index] = {div: batch_div, image: null, metadata: metadataRaw, overall_percent: 0, current_percent: 0};
                             let progress_bars = createDiv(null, 'image-preview-progress-wrapper', this.progressBarHtml);

--- a/src/wwwroot/js/genpage/helpers/generatehandler.js
+++ b/src/wwwroot/js/genpage/helpers/generatehandler.js
@@ -105,7 +105,7 @@ class GenerateHandler {
         imgHolder.image = src;
         imgHolder.div.dataset.src = src;
     }
-    
+
     doGenerate(input_overrides = {}, input_preoverrides = {}) {
         if (session_id == null) {
             if (Date.now() - time_started > 1000 * 60) {
@@ -198,7 +198,8 @@ class GenerateHandler {
                     let thisBatchId = `${batch_id}_${data.gen_progress.batch_index}`;
                     if (!(data.gen_progress.batch_index in images)) {
                         let metadataRaw = data.gen_progress.metadata ?? '{}';
-                        let batch_div = this.gotImagePreview(data.gen_progress.preview ?? `DOPLACEHOLDER:${actualInput.model || ''}`, metadataRaw, thisBatchId);
+                        let metadataParsed = (() => { try { return JSON.parse(metadataRaw); } catch { return {}; } })();
+                        let batch_div = this.gotImagePreview(data.gen_progress.preview ?? `DOPLACEHOLDER:${metadataParsed.sui_image_params?.model || ''}`, metadataRaw, thisBatchId);
                         if (batch_div) {
                             images[data.gen_progress.batch_index] = {div: batch_div, image: null, metadata: metadataRaw, overall_percent: 0, current_percent: 0};
                             let progress_bars = createDiv(null, 'image-preview-progress-wrapper', this.progressBarHtml);


### PR DESCRIPTION
## description

This PR addresses a UI bug where the placeholder image shown during image generation does not update when switching between different models. In the following sequence:

1. Generate an image with ModelA
2. Generate an image with Model B while Model A is in the process of generating an image.
3. During image generation with Model B, the placeholder for Model A is displayed instead of the placeholder for Model B.

## Impact & Notes:

Purely frontend change; no backend or API contract is affected.
I’m primarily a backend engineer—if anything looks off in the JS code, I’d really appreciate your feedback!