### PR TITLE
Outline currently selected image

### DIFF
--- a/src/wwwroot/css/genpage.css
+++ b/src/wwwroot/css/genpage.css
@@ -213,6 +213,11 @@ body {
     vertical-align: top;
     white-space: normal;
 }
+.image-block-selected {
+    outline: 2px solid var(--emphasis);
+    outline-offset: -2px;
+    z-index: 2;
+}
 .current-image-extras-wrapper {
     min-width: 20rem;
     vertical-align: top;

--- a/src/wwwroot/css/genpage.css
+++ b/src/wwwroot/css/genpage.css
@@ -218,6 +218,11 @@ body {
     outline-offset: -2px;
     z-index: 2;
 }
+.image-block-selected {
+    outline: 2px solid var(--emphasis);
+    outline-offset: -2px;
+    z-index: 2;
+}
 .current-image-extras-wrapper {
     min-width: 20rem;
     vertical-align: top;

--- a/src/wwwroot/js/genpage/gentab/currentimagehandler.js
+++ b/src/wwwroot/js/genpage/gentab/currentimagehandler.js
@@ -237,6 +237,13 @@ function toggleShowLoadSpinners() {
 }
 
 function clickImageInBatch(div) {
+    // Remove 'image-block-selected' from all image-blocks in the batch
+    document.querySelectorAll('#current_image_batch .image-block-selected').forEach(function (block) {
+        block.classList.remove('image-block-selected');
+    });
+    // Add 'image-block-selected' to the clicked block
+    div.classList.add('image-block-selected');
+
     let imgElem = div.getElementsByTagName('img')[0];
     if (currentImgSrc == div.dataset.src) {
         imageFullView.showImage(div.dataset.src, div.dataset.metadata);
@@ -244,6 +251,7 @@ function clickImageInBatch(div) {
     }
     setCurrentImage(div.dataset.src, div.dataset.metadata, div.dataset.batch_id ?? '', imgElem && imgElem.dataset.previewGrow == 'true', false, true, div.dataset.is_placeholder == 'true');
 }
+
 
 function rightClickImageInBatch(e, div) {
     if (e.shiftKey || e.ctrlKey) {
@@ -369,8 +377,7 @@ function shiftToNextImagePreview(next = true, expand = false) {
         let newIndex = index + (next ? 1 : -1);
         if (newIndex < 0) {
             newIndex = divs.length - 1;
-        }
-        else if (newIndex >= divs.length) {
+        } else if (newIndex >= divs.length) {
             newIndex = 0;
         }
         divs[newIndex].querySelector('img').click();
@@ -392,12 +399,19 @@ function shiftToNextImagePreview(next = true, expand = false) {
     let newIndex = index + (next ? 1 : -1);
     if (newIndex < 0) {
         newIndex = imgs.length - 1;
-    }
-    else if (newIndex >= imgs.length) {
+    } else if (newIndex >= imgs.length) {
         newIndex = 0;
     }
     let newImg = imgs[newIndex];
     let block = findParentOfClass(newImg, 'image-block');
+
+    // Remove 'image-block-selected' from all image-blocks
+    document.querySelectorAll('#current_image_batch .image-block-selected').forEach(function (block) {
+        block.classList.remove('image-block-selected');
+    });
+    // Add 'image-block-selected' to the new block
+    block.classList.add('image-block-selected');
+
     setCurrentImage(block.dataset.src, block.dataset.metadata, block.dataset.batch_id, newImg.dataset.previewGrow == 'true');
     if (expand) {
         imageFullView.showImage(block.dataset.src, block.dataset.metadata);
@@ -802,6 +816,26 @@ function setCurrentImage(src, metadata = '', batchId = '', previewGrow = false, 
         curImg.appendChild(img);
         curImg.appendChild(extrasWrapper);
     }
+
+    // Only remove selection from image history if we're not selecting a history image
+    if (batchId !== 'history') {
+        document.querySelectorAll('#imagehistorybrowser-content .image-block-selected')
+            .forEach((selected) => {
+                selected.classList.remove('image-block-selected');
+            });
+    }
+
+    // Always remove selection from current batch
+    document.querySelectorAll('#current_image_batch .image-block-selected').forEach(function (block) {
+        block.classList.remove('image-block-selected');
+    });
+
+    // Add selection to the current image block in the batch, if applicable
+    let currentBlock = document.querySelector(`#current_image_batch .image-block[data-src="${src}"]`);
+    if (currentBlock) {
+        currentBlock.classList.add('image-block-selected');
+    }
+
 }
 
 function appendImage(container, imageSrc, batchId, textPreview, metadata = '', type = 'legacy', prepend = true) {

--- a/src/wwwroot/js/genpage/gentab/currentimagehandler.js
+++ b/src/wwwroot/js/genpage/gentab/currentimagehandler.js
@@ -237,13 +237,10 @@ function toggleShowLoadSpinners() {
 }
 
 function clickImageInBatch(div) {
-    // Remove 'image-block-selected' from all image-blocks in the batch
-    document.querySelectorAll('#current_image_batch .image-block-selected').forEach(function (block) {
+    for (let block of document.querySelectorAll('#current_image_batch .image-block-selected')) {
         block.classList.remove('image-block-selected');
-    });
-    // Add 'image-block-selected' to the clicked block
+    }
     div.classList.add('image-block-selected');
-
     let imgElem = div.getElementsByTagName('img')[0];
     if (currentImgSrc == div.dataset.src) {
         imageFullView.showImage(div.dataset.src, div.dataset.metadata);
@@ -404,14 +401,10 @@ function shiftToNextImagePreview(next = true, expand = false) {
     }
     let newImg = imgs[newIndex];
     let block = findParentOfClass(newImg, 'image-block');
-
-    // Remove 'image-block-selected' from all image-blocks
-    document.querySelectorAll('#current_image_batch .image-block-selected').forEach(function (block) {
+    for (let block of document.querySelectorAll('#current_image_batch .image-block-selected')) {
         block.classList.remove('image-block-selected');
-    });
-    // Add 'image-block-selected' to the new block
+    }
     block.classList.add('image-block-selected');
-
     setCurrentImage(block.dataset.src, block.dataset.metadata, block.dataset.batch_id, newImg.dataset.previewGrow == 'true');
     if (expand) {
         imageFullView.showImage(block.dataset.src, block.dataset.metadata);
@@ -816,26 +809,18 @@ function setCurrentImage(src, metadata = '', batchId = '', previewGrow = false, 
         curImg.appendChild(img);
         curImg.appendChild(extrasWrapper);
     }
-
-    // Only remove selection from image history if we're not selecting a history image
-    if (batchId !== 'history') {
-        document.querySelectorAll('#imagehistorybrowser-content .image-block-selected')
-            .forEach((selected) => {
-                selected.classList.remove('image-block-selected');
-            });
+    if (batchId != 'history') {
+        for (let selected of document.querySelectorAll('#imagehistorybrowser-content .image-block-selected')) {
+            selected.classList.remove('image-block-selected');
+        }
     }
-
-    // Always remove selection from current batch
-    document.querySelectorAll('#current_image_batch .image-block-selected').forEach(function (block) {
+    for (let block of document.querySelectorAll('#current_image_batch .image-block-selected')) {
         block.classList.remove('image-block-selected');
-    });
-
-    // Add selection to the current image block in the batch, if applicable
+    }
     let currentBlock = document.querySelector(`#current_image_batch .image-block[data-src="${src}"]`);
     if (currentBlock) {
         currentBlock.classList.add('image-block-selected');
     }
-
 }
 
 function appendImage(container, imageSrc, batchId, textPreview, metadata = '', type = 'legacy', prepend = true) {

--- a/src/wwwroot/js/genpage/gentab/currentimagehandler.js
+++ b/src/wwwroot/js/genpage/gentab/currentimagehandler.js
@@ -249,7 +249,6 @@ function clickImageInBatch(div) {
     setCurrentImage(div.dataset.src, div.dataset.metadata, div.dataset.batch_id ?? '', imgElem && imgElem.dataset.previewGrow == 'true', false, true, div.dataset.is_placeholder == 'true');
 }
 
-
 function rightClickImageInBatch(e, div) {
     if (e.shiftKey || e.ctrlKey) {
         return;

--- a/src/wwwroot/js/genpage/gentab/currentimagehandler.js
+++ b/src/wwwroot/js/genpage/gentab/currentimagehandler.js
@@ -237,8 +237,7 @@ function toggleShowLoadSpinners() {
 }
 
 function clickImageInBatch(div) {
-    let currentImageBatchContent = document.getElementById('current_image_batch');
-    for (let block of currentImageBatchContent.querySelectorAll('.image-block-selected')) {
+    for (let block of getRequiredElementById('current_image_batch').querySelectorAll('.image-block-selected')) {
         block.classList.remove('image-block-selected');
     }
     div.classList.add('image-block-selected');
@@ -401,8 +400,7 @@ function shiftToNextImagePreview(next = true, expand = false) {
     }
     let newImg = imgs[newIndex];
     let block = findParentOfClass(newImg, 'image-block');
-    let currentImageBatchContent = document.getRequiredElementById('current_image_batch');
-    for (let block of currentImageBatchContent.querySelectorAll('.image-block-selected')) {
+    for (let block of getRequiredElementById('current_image_batch').querySelectorAll('.image-block-selected')) {
         block.classList.remove('image-block-selected');
     }
     block.classList.add('image-block-selected');
@@ -810,17 +808,15 @@ function setCurrentImage(src, metadata = '', batchId = '', previewGrow = false, 
         curImg.appendChild(img);
         curImg.appendChild(extrasWrapper);
     }
-    let imageHistoryBrowserContent = getRequiredElementById('imagehistorybrowser-content');
-    let currentImageBatchContent = getRequiredElementById('current_image_batch');
     if (batchId != 'history') {
-        for (let selected of imageHistoryBrowserContent.querySelectorAll('.image-block-selected')) {
+        for (let selected of getRequiredElementById('imagehistorybrowser-content').querySelectorAll('.image-block-selected')) {
             selected.classList.remove('image-block-selected');
         }
     }
-    for (let block of currentImageBatchContent.querySelectorAll('.image-block-selected')) {
+    for (let block of getRequiredElementById('current_image_batch').querySelectorAll('.image-block-selected')) {
         block.classList.remove('image-block-selected');
     }
-    let currentBlock = currentImageBatchContent.querySelector(`.image-block[data-src="${src}"]`);
+    let currentBlock = getRequiredElementById('current_image_batch').querySelector(`.image-block[data-src="${src}"]`);
     if (currentBlock) {
         currentBlock.classList.add('image-block-selected');
     }

--- a/src/wwwroot/js/genpage/gentab/currentimagehandler.js
+++ b/src/wwwroot/js/genpage/gentab/currentimagehandler.js
@@ -237,7 +237,8 @@ function toggleShowLoadSpinners() {
 }
 
 function clickImageInBatch(div) {
-    for (let block of document.querySelectorAll('#current_image_batch .image-block-selected')) {
+    let currentImageBatchContent = document.getElementById('current_image_batch');
+    for (let block of currentImageBatchContent.querySelectorAll('.image-block-selected')) {
         block.classList.remove('image-block-selected');
     }
     div.classList.add('image-block-selected');
@@ -400,7 +401,8 @@ function shiftToNextImagePreview(next = true, expand = false) {
     }
     let newImg = imgs[newIndex];
     let block = findParentOfClass(newImg, 'image-block');
-    for (let block of document.querySelectorAll('#current_image_batch .image-block-selected')) {
+    let currentImageBatchContent = document.getRequiredElementById('current_image_batch');
+    for (let block of currentImageBatchContent.querySelectorAll('.image-block-selected')) {
         block.classList.remove('image-block-selected');
     }
     block.classList.add('image-block-selected');
@@ -808,15 +810,17 @@ function setCurrentImage(src, metadata = '', batchId = '', previewGrow = false, 
         curImg.appendChild(img);
         curImg.appendChild(extrasWrapper);
     }
+    let imageHistoryBrowserContent = getRequiredElementById('imagehistorybrowser-content');
+    let currentImageBatchContent = getRequiredElementById('current_image_batch');
     if (batchId != 'history') {
-        for (let selected of document.querySelectorAll('#imagehistorybrowser-content .image-block-selected')) {
+        for (let selected of imageHistoryBrowserContent.querySelectorAll('.image-block-selected')) {
             selected.classList.remove('image-block-selected');
         }
     }
-    for (let block of document.querySelectorAll('#current_image_batch .image-block-selected')) {
+    for (let block of currentImageBatchContent.querySelectorAll('.image-block-selected')) {
         block.classList.remove('image-block-selected');
     }
-    let currentBlock = document.querySelector(`#current_image_batch .image-block[data-src="${src}"]`);
+    let currentBlock = currentImageBatchContent.querySelector(`.image-block[data-src="${src}"]`);
     if (currentBlock) {
         currentBlock.classList.add('image-block-selected');
     }

--- a/src/wwwroot/js/genpage/gentab/imagehistory.js
+++ b/src/wwwroot/js/genpage/gentab/imagehistory.js
@@ -139,16 +139,10 @@ function describeImage(image) {
 function selectImageInHistory(image, div) {
     lastHistoryImage = image.data.src;
     lastHistoryImageDiv = div;
-
-    // Remove 'image-block-selected' from all elements in the Image History section
-    document.querySelectorAll('.browser-list-entry.image-block-selected, .browser-details-list-entry.image-block-selected, .image-block.image-block-selected, .model-block.image-block-selected')
-        .forEach((selected) => {
-            selected.classList.remove('image-block-selected');
-        });
-
-    // Add 'image-block-selected' to the clicked element
+    for (let selected of document.querySelectorAll('.browser-list-entry.image-block-selected, .browser-details-list-entry.image-block-selected, .image-block.image-block-selected, .model-block.image-block-selected')) {
+        selected.classList.remove('image-block-selected');
+    }
     div.classList.add('image-block-selected');
-
     let curImg = document.getElementById('current_image_img');
     if (curImg && curImg.dataset.src == image.data.src) {
         curImg.dataset.batch_id = 'history';

--- a/src/wwwroot/js/genpage/gentab/imagehistory.js
+++ b/src/wwwroot/js/genpage/gentab/imagehistory.js
@@ -139,6 +139,16 @@ function describeImage(image) {
 function selectImageInHistory(image, div) {
     lastHistoryImage = image.data.src;
     lastHistoryImageDiv = div;
+
+    // Remove 'image-block-selected' from all elements in the Image History section
+    document.querySelectorAll('.browser-list-entry.image-block-selected, .browser-details-list-entry.image-block-selected, .image-block.image-block-selected, .model-block.image-block-selected')
+        .forEach((selected) => {
+            selected.classList.remove('image-block-selected');
+        });
+
+    // Add 'image-block-selected' to the clicked element
+    div.classList.add('image-block-selected');
+
     let curImg = document.getElementById('current_image_img');
     if (curImg && curImg.dataset.src == image.data.src) {
         curImg.dataset.batch_id = 'history';
@@ -147,8 +157,7 @@ function selectImageInHistory(image, div) {
     }
     if (image.data.name.endsWith('.html')) {
         window.open(image.data.src, '_blank');
-    }
-    else {
+    } else {
         if (!div.dataset.metadata) {
             div.dataset.metadata = image.data.metadata;
             div.dataset.src = image.data.src;


### PR DESCRIPTION
This new logic adds an outline to the currently selected image, whether from the image history or the current image batch.

More specifically, I have modified three files with the following code:
- genpage.css, which now contains style code for .image-block-selected, the outline using var --emphasis' color code to ensure that it's consistent with the current loaded theme.
- currentimagehandler.js, which now contains logic within function clickImageInBatch(div) that, upon clicking any image, removes the outline from any previously selected image, and adds the latest clicked image to the classList instead. Furthermore, some additional logic uses the existing "curImg.dataset.batch_id = 'history';" code to make an if(){} check, where if the batchId **is NOT** history, the selector will be removed from the image history as well.
- imagehistory.js, with similar logic to remove and add images into the classList.

There's also a few line breaks removed before some "else"s, which I left as they were. I can easily go back and reinsert the line breaks if desired.

Attached example images to showcase what this looks like with the default dark theme.

![image](https://github.com/user-attachments/assets/12442b66-9039-4008-9f97-d085ed8bb889)
![image](https://github.com/user-attachments/assets/8b38cd89-3d63-419a-8329-1435bba1febd)
