### PR TITLE
fixed: typo in markdown

### DIFF
--- a/docs/Video Model Support.md
+++ b/docs/Video Model Support.md
@@ -261,7 +261,7 @@ There's a full step by step guide for video model usage here: <https://github.co
 
 ![wan21_14b](https://github.com/user-attachments/assets/17ace901-bc5f-48d0-ab01-ed8984a1b1dc)
 
-*(Warn 2.1 - 14B Text2Video)*
+*(Wan 2.1 - 14B Text2Video)*
 
 ![wan21_13b](https://github.com/user-attachments/assets/51c40a08-9a05-4553-9785-67ae4fe8b2ac)
 


### PR DESCRIPTION
This PR fixed a typo I saw while reading the document `docs/Video Model Support.md`.

```patch
-*(Warn 2.1 - 14B Text2Video)*
+*(Wan 2.1 - 14B Text2Video)*
```