### PR TITLE
fix webp metadata

### DIFF
--- a/src/Utils/Image.cs
+++ b/src/Utils/Image.cs
@@ -263,7 +263,7 @@ public class Image
         using MemoryStream ms = new();
         ISImage img = ToIS;
         img.Metadata.XmpProfile = null;
-        ExifProfile prof = new();
+        ExifProfile prof = img.Metadata.ExifProfile?.DeepClone() ?? new ExifProfile();
         if (dpi > 0)
         {
             prof.SetValue(ExifTag.XResolution, new Rational((uint)dpi, 1));

--- a/src/Utils/ImageMetadataTracker.cs
+++ b/src/Utils/ImageMetadataTracker.cs
@@ -106,7 +106,7 @@ public static class ImageMetadataTracker
     }
 
     /// <summary>File format extensions that even can have metadata on them.</summary>
-    public static HashSet<string> ExtensionsWithMetadata = ["png", "jpg"];
+    public static HashSet<string> ExtensionsWithMetadata = ["png", "jpg", "webp"];
 
     /// <summary>File format extensions that require ffmpeg to process image data.</summary>
     public static HashSet<string> ExtensionsForFfmpegables = ["webm", "mp4", "mov"];


### PR DESCRIPTION
fixes encoding metadata into webp images

however dragging a webp image into swarm still doesnt show its metadata, i have no idea why, sorry

images from image history show metadata fine tho