### PR TITLE
Improve scrolling behavior in edit preset modal

### DIFF
--- a/src/wwwroot/css/genpage.css
+++ b/src/wwwroot/css/genpage.css
@@ -587,6 +587,27 @@ body {
 .modal_success_bottom {
     color: #00ff00;
 }
+
+/* These modals only scroll their body and keep a fixed header and footer */
+#add_preset_modal {
+    overflow-y: hidden;
+    max-height: calc(95vh - var(--bs-modal-margin));
+    margin-top: var(--bs-modal-margin);
+}
+
+#add_preset_modal .modal-dialog {
+    margin-top: 0;
+    margin-bottom: 0;
+    height: 100%;
+}
+
+#add_preset_modal .modal-content {
+    height: 100%;
+}
+#add_preset_modal .modal-body {
+    overflow-y: auto;
+}
+
 .preset-block-selected {
     border: 1px solid var(--box-selected-border);
     background-color: var(--box-selected-background);

--- a/src/wwwroot/css/genpage.css
+++ b/src/wwwroot/css/genpage.css
@@ -587,27 +587,21 @@ body {
 .modal_success_bottom {
     color: #00ff00;
 }
-
-/* These modals only scroll their body and keep a fixed header and footer */
 #add_preset_modal {
-    overflow-y: hidden;
     max-height: calc(95vh - var(--bs-modal-margin));
     margin-top: var(--bs-modal-margin);
 }
-
 #add_preset_modal .modal-dialog {
     margin-top: 0;
     margin-bottom: 0;
     height: 100%;
 }
-
 #add_preset_modal .modal-content {
     height: 100%;
 }
 #add_preset_modal .modal-body {
     overflow-y: auto;
 }
-
 .preset-block-selected {
     border: 1px solid var(--box-selected-border);
     background-color: var(--box-selected-background);


### PR DESCRIPTION
Currently the modal is several pages long and requires scrolling all the way to the bottom to reach the SAVE/CANCEL buttons.  This is painful if you are on a device that does not have a scroll gesture (because the scrollbar is also thin and if you try to grab it and miss you almost always inadvertently cancel the modal when your miss lands outside the window).

This commit makes the header and footer of the modal sticky and only the body of the modal scrolls. Thus the SAVE/CANCEL buttons are always available.

In theory this change could be applied globally to all modals.  But I limited the CSS change to just the preset modal to avoid tracking down every usage and ensuring there were no issues created by the change.