### PR TITLE
Add option to clear selected Tool from "Generate" dropdown

### DIFF
--- a/src/Pages/_Generate/GenerateTab.cshtml
+++ b/src/Pages/_Generate/GenerateTab.cshtml
@@ -115,14 +115,13 @@
                 <div class="sui_popover_model_button translate" onclick="mainGenHandler.doInterrupt(true)">Interrupt All Sessions</div>
                 <div class="sui_popover_model_button translate" onclick="mainGenHandler.doInterruptAndGen()" title="Alt+Click the Generate button to do this">Interrupt And Generate</div>
                 <div class="sui_popover_model_button translate" onclick="showPromptTokenizen('alt_prompt_textbox')">Show Prompt Tokenization</div>
-                <div class="sui_popover_model_button translate" onclick="disableSelectedTool()">Clear Selected Tool</div>
+                <div class="sui_popover_model_button translate" style="display:none" id="clear_selected_tool_button" onclick="disableSelectedTool()">Clear Selected Tool</div>
             </div>
             <div class="sui-popover sui_popover_model" id="popover_generate">
                 <div class="sui_popover_model_button translate" onclick="mainGenHandler.doGenerate()">Generate</div>
                 <div class="sui_popover_model_button translate" id="generate_forever_button" onclick="toggleGenerateForever()">Generate Forever</div>
                 <div class="sui_popover_model_button translate" id="generate_previews_button" onclick="toggleGeneratePreviews()">Generate Previews</div>
                 <div class="sui_popover_model_button translate" onclick="mainGenHandler.doInterruptAndGen()" title="Alt+Click the Generate button to do this">Interrupt And Generate</div>
-                <div class="sui_popover_model_button translate" onclick="disableSelectedTool()">Clear Selected Tool</div>
             </div>
             <div class="sui-popover sui_popover_model" id="popover_interrupt">
                 <div class="sui_popover_model_button translate" onclick="mainGenHandler.doInterrupt()">Interrupt Current Session</div>

--- a/src/wwwroot/js/genpage/main.js
+++ b/src/wwwroot/js/genpage/main.js
@@ -245,6 +245,7 @@ function genToolsList() {
         }
         let tool = toolSelector.value;
         if (tool == '') {
+            getRequiredElementById('clear_selected_tool_button').style.display = 'none';
             return;
         }
         let div = getRequiredElementById(`tool_${tool}`);
@@ -258,6 +259,7 @@ function genToolsList() {
             }
         }
         div.dispatchEvent(new Event('tool-opened'));
+        getRequiredElementById('clear_selected_tool_button').style.display = '';
     });
 }
 
@@ -274,6 +276,10 @@ function registerNewTool(id, name, genOverride = null, runOverride = null) {
         toolOverrides[id] = { 'text': genOverride, 'run': runOverride };
     }
     return div;
+}
+function disableSelectedTool() {
+    toolSelector.value = '';
+    triggerChangeFor(toolSelector);
 }
 
 let notePadTool = registerNewTool('note_pad', 'Text Notepad');

--- a/src/wwwroot/js/genpage/utiltab.js
+++ b/src/wwwroot/js/genpage/utiltab.js
@@ -51,12 +51,6 @@ function showPromptTokenizen(box) {
     triggerChangeFor(target);
 }
 
-function disableSelectedTool() {
-    let target = document.querySelector('#Tools-Tab #tool_selector');
-    target.value = "";
-    triggerChangeFor(target)
-}
-
 /** Preloads conversion data. */
 function pickle2safetensor_load(mapping = null) {
     if (mapping == null) {


### PR DESCRIPTION
Simple PR that adds a "Clear Selected Tool" to the Generate button, so I don't have to go into the Tools tab and select from the dropdown each time.

I would prefer this to only be displayed if a tool is actually selected. I don't see any pre-existing conditional logic in the app to handle this. Would you prefer leaving it as-is or adding a JS check that only shows the option if a tool is selected?

![Screenshot 2025-07-03 at 13 39 54](https://github.com/user-attachments/assets/78b8370a-b937-415f-9bd6-597c6ad6d66d)
