### PR TITLE
Add Image Selector in SwarmInputImage

### DIFF
--- a/src/BuiltinExtensions/ComfyUIBackend/Assets/comfy_workflow_editor_helper.js
+++ b/src/BuiltinExtensions/ComfyUIBackend/Assets/comfy_workflow_editor_helper.js
@@ -502,7 +502,6 @@ function comfyBuildParams(callback) {
                     break;
                     case 'SwarmInputBoolean': type = 'boolean'; doFixMe = true; break;
                     case 'SwarmInputImage': type = 'image'; break;
-                    case 'SwarmInputImageWithSelector': type = 'image'; break;
                     default: throw new Error(`Unknown SwarmInput type ${node.class_type}`);
                 }
                 let inputIdDirect = node.inputs['raw_id'] || cleanParamName(node.inputs['title']);
@@ -547,7 +546,7 @@ function comfyBuildParams(callback) {
                     no_popover: node.inputs['description'].length == 0,
                     group: groupObj
                 };
-                if (node.class_type == 'SwarmInputImage' || node.class_type == 'SwarmInputImageWithSelector') {
+                if (node.class_type == 'SwarmInputImage') {
                     params[inputId].image_should_resize = node.inputs['auto_resize'];
                     params[inputId].image_always_b64 = true;
                 }

--- a/src/BuiltinExtensions/ComfyUIBackend/Assets/comfy_workflow_editor_helper.js
+++ b/src/BuiltinExtensions/ComfyUIBackend/Assets/comfy_workflow_editor_helper.js
@@ -502,6 +502,7 @@ function comfyBuildParams(callback) {
                     break;
                     case 'SwarmInputBoolean': type = 'boolean'; doFixMe = true; break;
                     case 'SwarmInputImage': type = 'image'; break;
+                    case 'SwarmInputImageWithSelector': type = 'image'; break;
                     default: throw new Error(`Unknown SwarmInput type ${node.class_type}`);
                 }
                 let inputIdDirect = node.inputs['raw_id'] || cleanParamName(node.inputs['title']);
@@ -546,7 +547,7 @@ function comfyBuildParams(callback) {
                     no_popover: node.inputs['description'].length == 0,
                     group: groupObj
                 };
-                if (node.class_type == 'SwarmInputImage') {
+                if (node.class_type == 'SwarmInputImage' || node.class_type == 'SwarmInputImageWithSelector') {
                     params[inputId].image_should_resize = node.inputs['auto_resize'];
                     params[inputId].image_always_b64 = true;
                 }

--- a/src/BuiltinExtensions/ComfyUIBackend/ExtraNodes/SwarmComfyCommon/SwarmInputNodes.py
+++ b/src/BuiltinExtensions/ComfyUIBackend/ExtraNodes/SwarmComfyCommon/SwarmInputNodes.py
@@ -187,8 +187,8 @@ class SwarmInputBoolean:
     def do_input(self, value, **kwargs):
         return (value, )
 
+
 class SwarmInputImage:
-    DEFAULT_VALUE_TEXT = "(Do Not Set Me)"
     @classmethod
     def INPUT_TYPES(s):
         input_dir = folder_paths.get_input_directory()
@@ -197,11 +197,9 @@ class SwarmInputImage:
         return {
             "required": {
                 "title": ("STRING", {"default": "My Image", "tooltip": "The name of the input."}),
-                "value": ("STRING", {"default": s.DEFAULT_VALUE_TEXT, "multiline": True, "tooltip": "Always leave this blank, the SwarmUI server will fill it for you."}),
+                "value": ("STRING", {"default": "(Do Not Set Me)", "multiline": True, "tooltip": "Always leave this blank, the SwarmUI server will fill it for you."}),
                 "auto_resize": ("BOOLEAN", {"default": True, "tooltip": "If true, the image will be resized to match the current generation resolution. If false, the image will be kept at whatever size the user input it at."}),
-            } |
-            STANDARD_REQ_INPUTS |
-            {
+            } | STANDARD_REQ_INPUTS | {
                 "image": (sorted(files), {"image_upload": True}),
             },
         } | STANDARD_OTHER_INPUTS
@@ -212,7 +210,7 @@ class SwarmInputImage:
     DESCRIPTION = "SwarmInput nodes let you define custom input controls in Swarm-Comfy Workflows. Image lets you input an image. Internally this node uses a Base64 string as input when value is set by SwarmUI server (Generate tab), otherwise use select Image (Comfy Workflow tab)."
 
     def do_input(self, value=None, image=None, **kwargs):
-        if not value or value==self.DEFAULT_VALUE_TEXT:
+        if not value or value == "(Do Not Set Me)":
             return LoadImage().load_image(image)
         else:
             return SwarmLoadImageB64.b64_to_img_and_mask(value)

--- a/src/BuiltinExtensions/ComfyUIBackend/ExtraNodes/SwarmComfyCommon/SwarmInputNodes.py
+++ b/src/BuiltinExtensions/ComfyUIBackend/ExtraNodes/SwarmComfyCommon/SwarmInputNodes.py
@@ -1,12 +1,7 @@
 from . import SwarmLoadImageB64
 import folder_paths
-from nodes import CheckpointLoaderSimple
+from nodes import CheckpointLoaderSimple, LoadImage
 import os
-
-import node_helpers
-from PIL import Image, ImageOps, ImageSequence
-import numpy as np
-import torch
 
 INT_MAX = 0xffffffffffffffff
 INT_MIN = -INT_MAX
@@ -192,53 +187,6 @@ class SwarmInputBoolean:
     def do_input(self, value, **kwargs):
         return (value, )
 
-def load_image(image):
-    image_path = folder_paths.get_annotated_filepath(image)
-
-    img = node_helpers.pillow(Image.open, image_path)
-
-    output_images = []
-    output_masks = []
-    w, h = None, None
-
-    excluded_formats = ['MPO']
-
-    for i in ImageSequence.Iterator(img):
-        i = node_helpers.pillow(ImageOps.exif_transpose, i)
-
-        if i.mode == 'I':
-            i = i.point(lambda i: i * (1 / 255))
-        image = i.convert("RGB")
-
-        if len(output_images) == 0:
-            w = image.size[0]
-            h = image.size[1]
-
-        if image.size[0] != w or image.size[1] != h:
-            continue
-
-        image = np.array(image).astype(np.float32) / 255.0
-        image = torch.from_numpy(image)[None,]
-        if 'A' in i.getbands():
-            mask = np.array(i.getchannel('A')).astype(np.float32) / 255.0
-            mask = 1. - torch.from_numpy(mask)
-        elif i.mode == 'P' and 'transparency' in i.info:
-            mask = np.array(i.convert('RGBA').getchannel('A')).astype(np.float32) / 255.0
-            mask = 1. - torch.from_numpy(mask)
-        else:
-            mask = torch.zeros((64,64), dtype=torch.float32, device="cpu")
-        output_images.append(image)
-        output_masks.append(mask.unsqueeze(0))
-
-    if len(output_images) > 1 and img.format not in excluded_formats:
-        output_image = torch.cat(output_images, dim=0)
-        output_mask = torch.cat(output_masks, dim=0)
-    else:
-        output_image = output_images[0]
-        output_mask = output_masks[0]
-
-    return (output_image, output_mask)
-
 class SwarmInputImage:
     DEFAULT_VALUE_TEXT = "(Do Not Set Me)"
     @classmethod
@@ -265,7 +213,7 @@ class SwarmInputImage:
 
     def do_input(self, value=None, image=None, **kwargs):
         if not value or value==self.DEFAULT_VALUE_TEXT:
-            return load_image(image)
+            return LoadImage().load_image(image)
         else:
             return SwarmLoadImageB64.b64_to_img_and_mask(value)
 

--- a/src/BuiltinExtensions/ComfyUIBackend/ExtraNodes/SwarmComfyCommon/SwarmInputNodes.py
+++ b/src/BuiltinExtensions/ComfyUIBackend/ExtraNodes/SwarmComfyCommon/SwarmInputNodes.py
@@ -192,25 +192,6 @@ class SwarmInputBoolean:
     def do_input(self, value, **kwargs):
         return (value, )
 
-class SwarmInputImage:
-    @classmethod
-    def INPUT_TYPES(s):
-        return {
-            "required": {
-                "title": ("STRING", {"default": "My Image", "tooltip": "The name of the input."}),
-                "value": ("STRING", {"default": "(Do Not Set Me)", "multiline": True, "tooltip": "Always leave this blank, the SwarmUI server will fill it for you."}),
-                "auto_resize": ("BOOLEAN", {"default": True, "tooltip": "If true, the image will be resized to match the current generation resolution. If false, the image will be kept at whatever size the user input it at."}),
-            } | STANDARD_REQ_INPUTS,
-        } | STANDARD_OTHER_INPUTS
-
-    CATEGORY = "SwarmUI/inputs"
-    RETURN_TYPES = ("IMAGE","MASK",)
-    FUNCTION = "do_input"
-    DESCRIPTION = "SwarmInput nodes let you define custom input controls in Swarm-Comfy Workflows. Image lets you input an image. Internally this node uses a Base64 string as input, so may not be the most friendly to use on the Comfy Workflow tab, but is very convenient to use on the Generate tab."
-
-    def do_input(self, value, **kwargs):
-        return SwarmLoadImageB64.b64_to_img_and_mask(value)
-
 def load_image(image):
     image_path = folder_paths.get_annotated_filepath(image)
 
@@ -258,7 +239,7 @@ def load_image(image):
 
     return (output_image, output_mask)
 
-class SwarmInputImageWithSelector:
+class SwarmInputImage:
     DEFAULT_VALUE_TEXT = "(Do Not Set Me)"
     @classmethod
     def INPUT_TYPES(s):
@@ -268,18 +249,19 @@ class SwarmInputImageWithSelector:
         return {
             "required": {
                 "title": ("STRING", {"default": "My Image", "tooltip": "The name of the input."}),
-                "auto_resize": ("BOOLEAN", {"default": True, "tooltip": "If true, the image will be resized to match the current generation resolution. If false, the image will be kept at whatever size the user input it at."}),
-                "image": (sorted(files), {"image_upload": True}),
-            } | STANDARD_REQ_INPUTS,
-            "hidden":{
                 "value": ("STRING", {"default": s.DEFAULT_VALUE_TEXT, "multiline": True, "tooltip": "Always leave this blank, the SwarmUI server will fill it for you."}),
+                "auto_resize": ("BOOLEAN", {"default": True, "tooltip": "If true, the image will be resized to match the current generation resolution. If false, the image will be kept at whatever size the user input it at."}),
+            } |
+            STANDARD_REQ_INPUTS |
+            {
+                "image": (sorted(files), {"image_upload": True}),
             },
         } | STANDARD_OTHER_INPUTS
 
     CATEGORY = "SwarmUI/inputs"
     RETURN_TYPES = ("IMAGE","MASK",)
     FUNCTION = "do_input"
-    DESCRIPTION = "SwarmInputImageWithSelector nodes let you define custom input controls in Swarm-Comfy Workflows. Internally SwarmInputImage only uses a Base64 string as input. this node use Image in Comfy Workflow tab, and also support Base64 string on the Generate tab."
+    DESCRIPTION = "SwarmInput nodes let you define custom input controls in Swarm-Comfy Workflows. Image lets you input an image. Internally this node uses a Base64 string as input when value is set by SwarmUI server (Generate tab), otherwise use select Image (Comfy Workflow tab)."
 
     def do_input(self, value=None, image=None, **kwargs):
         if not value or value==self.DEFAULT_VALUE_TEXT:
@@ -298,5 +280,4 @@ NODE_CLASS_MAPPINGS = {
     "SwarmInputDropdown": SwarmInputDropdown,
     "SwarmInputBoolean": SwarmInputBoolean,
     "SwarmInputImage": SwarmInputImage,
-    "SwarmInputImageWithSelector": SwarmInputImageWithSelector,
 }


### PR DESCRIPTION
Add Image Selector in SwarmInputImage, just like the original LoadImage node.
It works in all three tabs: ComfyUI, Generate, and Simple

![SwarmInputImageImageSelector](https://github.com/user-attachments/assets/2d8bdaba-7fe6-4991-9acc-b28d9692ccdf)