### PR TITLE
do not remove 2x items from chunkSize from remainingFiles when building item list

### DIFF
--- a/src/wwwroot/js/genpage/helpers/browsers.js
+++ b/src/wwwroot/js/genpage/helpers/browsers.js
@@ -373,7 +373,6 @@ class GenPageBrowserClass {
                 while (remainingFiles.length > 0) {
                     let chunkSize = Math.min(this.maxPreBuild / 2, remainingFiles.length, 100);
                     let chunk = remainingFiles.splice(0, chunkSize);
-                    remainingFiles = remainingFiles.slice(chunkSize);
                     let sectionDiv = createDiv(null, 'lazyload browser-section-loader');
                     sectionDiv.onclick = () => {
                         this.buildContentList(container, chunk, sectionDiv, id);


### PR DESCRIPTION
I had 646 images in my list and noticed the last 33 or so were not being shown.  Caused by a bug where 2x chunkSize were being removed from list instead of 1x chunkSize (splice removes the first chunkSize, then slice removed another chunkSize)