### PR TITLE
Item browser performance improvements

### DIFF
--- a/src/wwwroot/css/genpage.css
+++ b/src/wwwroot/css/genpage.css
@@ -252,8 +252,6 @@ body {
 .image-block img, .img-block video {
     display: block;
     margin: auto;
-    padding-left: 0.4rem;
-    padding-right: 0.4rem;
 }
 .image-block-placeholder img {
     filter: blur(5px);
@@ -264,6 +262,7 @@ body {
 .image-block-legacy {
     position: relative;
     height: 11.5rem;
+    width: 10rem;
     padding-top: 0.1rem;
     padding-left: 0.1rem;
     padding-right: 0.1rem;
@@ -273,12 +272,15 @@ body {
 }
 .image-block-small {
     height: 7rem;
+    width: 7rem;
 }
 .image-block-big {
     height: 17.5rem;
+    width: 16rem;
 }
 .image-block-giant {
     height: 27.5rem;
+    width: 26rem;
 }
 .image-block-legacy img {
     height: 8rem;

--- a/src/wwwroot/css/genpage.css
+++ b/src/wwwroot/css/genpage.css
@@ -364,7 +364,6 @@ body {
 }
 .image-preview-text {
     font-family: var(--font-monospace);
-    /* this dark magic will make the text grow as big as the parent container is and then wrap (instead of growing the container even more) */
     min-width: 100%;
     max-width: 0;
 }

--- a/src/wwwroot/css/genpage.css
+++ b/src/wwwroot/css/genpage.css
@@ -252,6 +252,8 @@ body {
 .image-block img, .img-block video {
     display: block;
     margin: auto;
+    padding-left: 0.4rem;
+    padding-right: 0.4rem;
 }
 .image-block-placeholder img {
     filter: blur(5px);
@@ -262,7 +264,6 @@ body {
 .image-block-legacy {
     position: relative;
     height: 11.5rem;
-    width: 10rem;
     padding-top: 0.1rem;
     padding-left: 0.1rem;
     padding-right: 0.1rem;
@@ -272,15 +273,12 @@ body {
 }
 .image-block-small {
     height: 7rem;
-    width: 7rem;
 }
 .image-block-big {
     height: 17.5rem;
-    width: 16rem;
 }
 .image-block-giant {
     height: 27.5rem;
-    width: 26rem;
 }
 .image-block-legacy img {
     height: 8rem;
@@ -366,6 +364,9 @@ body {
 }
 .image-preview-text {
     font-family: var(--font-monospace);
+    /* this dark magic will make the text grow as big as the parent container is and then wrap (instead of growing the container even more) */
+    min-width: 100%;
+    max-width: 0;
 }
 .current_model_view {
     display: inline-block;

--- a/src/wwwroot/js/genpage/gentab/imagehistory.js
+++ b/src/wwwroot/js/genpage/gentab/imagehistory.js
@@ -149,7 +149,7 @@ function describeImage(image) {
     let imageSrc = image.data.src.endsWith('.html') ? 'imgs/html.jpg' : `${image.data.src}?preview=true${allowAnimToggle}`;
     let searchable = `${image.data.name}, ${image.data.metadata}, ${image.data.fullsrc}`;
     let detail_list = [escapeHtml(image.data.name), formattedMetadata.replaceAll('<br>', '&emsp;')];
-    let aspectRatio = parsedMeta.sui_image_params?.width && parsedMeta.sui_image_params?.height ? parsedMeta.sui_image_params.width / parsedMeta.sui_image_params.height : 1;
+    let aspectRatio = parsedMeta.sui_image_params?.width && parsedMeta.sui_image_params?.height ? parsedMeta.sui_image_params.width / parsedMeta.sui_image_params.height : null;
     return { name, description, buttons, 'image': imageSrc, 'dragimage': dragImage, className: parsedMeta.is_starred ? 'image-block-starred' : '', searchable, display: name, detail_list, aspectRatio };
 }
 

--- a/src/wwwroot/js/genpage/gentab/imagehistory.js
+++ b/src/wwwroot/js/genpage/gentab/imagehistory.js
@@ -149,7 +149,8 @@ function describeImage(image) {
     let imageSrc = image.data.src.endsWith('.html') ? 'imgs/html.jpg' : `${image.data.src}?preview=true${allowAnimToggle}`;
     let searchable = `${image.data.name}, ${image.data.metadata}, ${image.data.fullsrc}`;
     let detail_list = [escapeHtml(image.data.name), formattedMetadata.replaceAll('<br>', '&emsp;')];
-    return { name, description, buttons, 'image': imageSrc, 'dragimage': dragImage, className: parsedMeta.is_starred ? 'image-block-starred' : '', searchable, display: name, detail_list };
+    let aspectRatio = parsedMeta.sui_image_params?.width && parsedMeta.sui_image_params?.height ? parsedMeta.sui_image_params.width / parsedMeta.sui_image_params.height : 1;
+    return { name, description, buttons, 'image': imageSrc, 'dragimage': dragImage, className: parsedMeta.is_starred ? 'image-block-starred' : '', searchable, display: name, detail_list, aspectRatio };
 }
 
 function selectImageInHistory(image, div) {

--- a/src/wwwroot/js/genpage/helpers/browsers.js
+++ b/src/wwwroot/js/genpage/helpers/browsers.js
@@ -489,7 +489,8 @@ class GenPageBrowserClass {
                 div.appendChild(menu);
             }
             if (!this.format.includes('Cards')) {
-                div.title = stripHtmlToText(desc.description);
+                // stripping HTML is very expensive.  Only do it the first time the mouse enters the div
+                div.addEventListener('mouseenter', () => div.title = stripHtmlToText(desc.description), { once: true });
             }
             div.dataset.name = file.name;
             img.classList.add('lazyload');

--- a/src/wwwroot/js/genpage/helpers/browsers.js
+++ b/src/wwwroot/js/genpage/helpers/browsers.js
@@ -722,7 +722,9 @@ class GenPageBrowserClass {
         this.headerBar.appendChild(this.headerCount);
         this.buildTreeElements(this.folderTreeDiv, '', this.tree);
         this.buildContentList(this.contentDiv, files);
-        this.folderTreeDiv.scrollTop = folderScroll;
+        if (folderScroll) {
+            this.folderTreeDiv.scrollTop = folderScroll;
+        }
         browserUtil.makeVisible(this.contentDiv);
         if (scrollOffset) {
             this.contentDiv.scrollTop = scrollOffset;

--- a/src/wwwroot/js/genpage/helpers/browsers.js
+++ b/src/wwwroot/js/genpage/helpers/browsers.js
@@ -432,11 +432,8 @@ class GenPageBrowserClass {
                 if (this.format.startsWith('Big')) { factor = 15; div.classList.add('image-block-big'); }
                 else if (this.format.startsWith('Giant')) { factor = 25; div.classList.add('image-block-giant'); }
                 else if (this.format.startsWith('Small')) { factor = 5; div.classList.add('image-block-small'); }
-                div.style.width = `${factor + 1}rem`;
-                img.addEventListener('load', () => {
-                    let ratio = img.width / img.height;
-                    div.style.width = `${(ratio * factor) + 1}rem`;
-                });
+                // use the aspect ratio based on image metadata we know and then automatically switch to actual image aspect ratio when the image loads.
+                img.style.aspectRatio = `auto ${desc.aspectRatio || 1}`;
                 let textBlock = createDiv(null, 'image-preview-text');
                 textBlock.innerText = desc.display || desc.name;
                 if (this.format == "Small Thumbnails" || textBlock.innerText.length > 40) {

--- a/src/wwwroot/js/genpage/helpers/browsers.js
+++ b/src/wwwroot/js/genpage/helpers/browsers.js
@@ -5,11 +5,16 @@ class BrowserUtil {
      * Make any visible images within a container actually load now.
      */
     makeVisible(elem) {
-        for (let subElem of elem.querySelectorAll('.lazyload')) {
-            let top = subElem.getBoundingClientRect().top;
-            if (top >= window.innerHeight + 512 || top == 0) { // Note top=0 means not visible
-                continue;
-            }
+        // collect list of lazyload elements we want to load first
+        // then trigger their loading second.
+        // this avoids repetitive reflows and just causes 1 reflow at first measurement
+        let elementsToLoad = Array.from(elem.querySelectorAll('.lazyload'))
+            .filter(e => {
+                let top = e.getBoundingClientRect().top;
+                // Note top=0 means not visible
+                return top > 0 && top < window.innerHeight + 512;
+            });
+        for (let subElem of elementsToLoad) {
             subElem.classList.remove('lazyload');
             if (subElem.tagName == 'IMG') {
                 if (!subElem.dataset.src) {


### PR DESCRIPTION
ok I was getting frustrated by all the flashing and slow updating of the Image History tab when refreshing it.  It is ESPECIALLY bad if I am in a nested folder.  If I am in a/b/c/d, then refreshing causes it to flash with the contents of a, then a/b, then a/b/c and finally a/b/c/d.  And if I have 1000 images those flashes are slow.

So here are some performance updates.  I put each specific update in a separate commit in case you have any reservations we can just cherry pick the ones you will take.  They are generally in order from least-risky to most-risky (only the last one is actually risky).

If you take them all, for my test case (nested folder with 646 images), clicking Refresh originally took 11+ seconds.  Now it takes only 2.2 seconds. 

Here are a bunch of profiler screenshots....

### Original Behavior

If I am viewing this nested folder with 646 images:

<img width="1493" height="620" alt="image" src="https://github.com/user-attachments/assets/294cb637-56aa-43aa-a7f8-be4613f4cec4" />

And I click Refresh, the original code with all its flashing ends up fetching the ImageList from the server 4 times and  takes **11+ seconds** to settle down.  This is what the flamegraph looks like:

<img width="1670" height="911" alt="image" src="https://github.com/user-attachments/assets/80a65023-d818-43fd-a9fc-2d3f43e90488" />

Lots of Reflow.  Lots of script cpu time.  The image list is re-rendered 4 times I think.

### Updated Behavior

With all the changes, the refresh runs in 2.2 seconds and the profile looks like:

<img width="1672" height="906" alt="image" src="https://github.com/user-attachments/assets/d8378e36-0f8c-4af8-a8f0-9354496494bb" />

We've removed many of the extra calls to ListImages.  We've removed most of the reflow.  We've reduced the script-time spent generating html.  We've reduced the number of times the list gets re-rendered.

# Progressive improvements

if you zoom in on a single render of the root folder with 1200 images, it takes about **2.4s**.

<img width="1896" height="1149" alt="image" src="https://github.com/user-attachments/assets/4af8800c-2844-434d-b851-d5f47dacb37f" />

There is a huge chunk when the html is generated, and then a bunch of trailing reflows as images are loaded.

## Commit 1 - thumbnail aspect ratio

All of the trailing reflow after render was caused by the images loading and the thumbnail aspect ratio being modified from 1:1 to whatever the image aspect ratio was.  But for Image History, we usually know what the ratio is for each image when we are initializing the thumbnail.  So just setting that and using some css tricks to update it without JavaScript when the image finally arrives (if it does not match the ratio we pre-computed) makes it so the thumbnails end up being correctly sized from the start and all the reflow on image load vanishes.  It makes it faster and as a bonus the user doesnt see the tiles moving around anymore.

This drops the single-render time to roughly **900ms**.

<img width="1883" height="1129" alt="image" src="https://github.com/user-attachments/assets/09116adc-bee4-4172-aad6-e7f4061be82a" />

## Commit 2

I was trying to eliminate the reflow caused by setting scrollTop.  I changed the code to only set it if it is > 0.  All this really did was move the reflow to `makeVisible`, but that's ok....

## Commit 3

Because now that makeVisible is the bottleneck, we can optimize it.  Instead of a tight loop of (read DOM, modify DOM) which causes a tight loop of reflow, we instead do all the DOM reading first, then do all the DOM modifications second.  I've lost my profile, but I think this got the render time down to around 750ms.

## Commit 4

I notice a lot of time is spent parsing html. It's the code that converts an html description into a text title.  html->text is pretty slow if using the DOM to do it.  And why do it on 1000 items just in case someone is going to move their mouse over 1 or 2 and get a tooltip?  So I modified the code to do it on demand only when the user actually moves the mouse into the element.

This change got the single-render time down to roughly 600ms.

## Commit 5

This one is the most risky.  I tackled the problem of the multiple calls to GetItemList and multiple renders of the items.  Now it makes one call to get the root files/folders (used to populate the folder list) and then only makes calls when it gets to the depth limit and hasnt reached the target folder yet.  And while it is traversing the tree, it refrains from rendering the items.  Only once it hits the target tree node does it make a final call to get the files at this depth, then renders them.

This commit is only risky in the sense that it's possible I broke the refresh on some tab I'm not familiar with.  Hopefully you can test it as well.  I've tried it with a couple of different depth settings (1, 2, 6) and it seems to work correctly.