### PR TITLE
When using mask-shrink grow with Kontext, apply the scaled area to the Reference latent too

### DIFF
--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGenerator.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGenerator.cs
@@ -1650,6 +1650,11 @@ public class WorkflowGenerator
                     makeRefLatent(img);
                 }
             }
+            else if (MaskShrunkInfo is not null && MaskShrunkInfo.ScaledImage is not null)
+            {
+                img = [MaskShrunkInfo.ScaledImage, 0];
+                makeRefLatent(img);
+            }
             else if (FinalInputImage is not null)
             {
                 img = FinalInputImage;


### PR DESCRIPTION
Currently, when you use mask-shrink-grow with kontext, the Scaled and Cropped image is applied to the SwarmKSampler 'Latent image' input, but it's not applied to the ReferenceLatent that produces the conditioning.

Example workflow:
![kontext_mask_workflow_before](https://github.com/user-attachments/assets/1feb11c0-b52b-4dd1-9de3-f64bc7deb7e4)

In practice, this means that it starts out trying to apply a miniature version of the whole image to the masked area. Sometimes the diffusion steps allow it to recover from this bad start, sometimes not.

Example: (prompt is 'replace the fries with chicken nuggets', masked over a box of fries in the middle of the tray) 
![0926-replace the fries with chicken nuggets-svdq-int4_r32-flux1-kontext-dev-8510001](https://github.com/user-attachments/assets/c914cf87-9bff-40c8-91df-a0d8d91a9bf3)

Using the scaled image as the ReferenceLatent input produces a better result. (imitating https://github.com/mcmonkeyprojects/SwarmUI/commit/8eb77e578b207d28dcaa968c5412b041f662ad2d here).

Workflow:
![kontext_mask_workflow_after](https://github.com/user-attachments/assets/451df8ba-258e-4d46-abd8-7428bab194eb)

Output:
![0939-replace the fries with chicken nuggets-svdq-int4_r32-flux1-kontext-dev-8510001](https://github.com/user-attachments/assets/ad9dc21b-a058-4ea0-995e-9b50e4fb3b13)



(i) I don't know how common it is to use masks with Flux Kontext - I find it's useful for restricting the change to a given area, because Kontext often makes subtle changes to the angle or the lighting of a scene even when you prompt it hard to leave everything but the intended change alone. I'm hoping that mask-shrink-grow will give quality improvements in details.

(ii) I don't know how this would work with prompting with multiple images, but I'm not sure how you'd use a mask in that use case anyway. Based on the if this change should only apply when there's a single image.


