### PR TITLE
Support Numbers Larger Than int32 for `T2IParamDataType.INTEGER`

### DIFF
--- a/src/BuiltinExtensions/ComfyUIBackend/ComfyUIAPIAbstractBackend.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/ComfyUIAPIAbstractBackend.cs
@@ -739,8 +739,8 @@ public abstract class ComfyUIAPIAbstractBackend : AbstractT2IBackend
                     }
                     if (type.Type == T2IParamDataType.INTEGER && type.ViewType == ParamViewType.SEED && long.Parse(val.ToString()) == -1)
                     {
-                        long max = (long)type.Max;
-                        return $"{Random.Shared.NextInt64(0, max <= 0 ? long.MaxValue : max)}";
+                        int max = (int)type.Max;
+                        return $"{Random.Shared.Next(0, max <= 0 ? int.MaxValue : max)}";
                     }
                     if (val is T2IModel model)
                     {

--- a/src/BuiltinExtensions/ComfyUIBackend/ComfyUIAPIAbstractBackend.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/ComfyUIAPIAbstractBackend.cs
@@ -739,8 +739,8 @@ public abstract class ComfyUIAPIAbstractBackend : AbstractT2IBackend
                     }
                     if (type.Type == T2IParamDataType.INTEGER && type.ViewType == ParamViewType.SEED && long.Parse(val.ToString()) == -1)
                     {
-                        int max = (int)type.Max;
-                        return $"{Random.Shared.Next(0, max <= 0 ? int.MaxValue : max)}";
+                        long max = (long)type.Max;
+                        return $"{Random.Shared.NextInt64(0, max <= 0 ? long.MaxValue : max)}";
                     }
                     if (val is T2IModel model)
                     {

--- a/src/BuiltinExtensions/ComfyUIBackend/ComfyUIBackendExtension.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/ComfyUIBackendExtension.cs
@@ -200,8 +200,8 @@ public class ComfyUIBackendExtension : Extension
                             long parsed = long.Parse(newVal);
                             if (parsed == -1)
                             {
-                                long max = (long)type.Max;
-                                parsed = Random.Shared.NextInt64(0, max <= 0 ? long.MaxValue : max);
+                                int max = (int)type.Max;
+                                parsed = Random.Shared.Next(0, max <= 0 ? int.MaxValue : max);
                             }
                             return parsed.ToString();
                         }
@@ -227,7 +227,7 @@ public class ComfyUIBackendExtension : Extension
                         long parsed = long.Parse(newVal);
                         if (parsed == -1)
                         {
-                            parsed = Random.Shared.NextInt64(0, long.MaxValue);
+                            parsed = Random.Shared.Next(0, int.MaxValue);
                         }
                         return parsed.ToString();
                     }
@@ -417,7 +417,7 @@ public class ComfyUIBackendExtension : Extension
     }
 
     public static LockObject ValueAssignmentLocker = new();
-
+    
     /// <summary>Add handlers here to do additional parsing of RawObjectInfo data.</summary>
     public static List<Action<JObject>> RawObjectInfoParsers = [];
 

--- a/src/BuiltinExtensions/ComfyUIBackend/ComfyUIBackendExtension.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/ComfyUIBackendExtension.cs
@@ -197,11 +197,11 @@ public class ComfyUIBackendExtension : Extension
                     {
                         string seedClean(string prior, string newVal)
                         {
-                            int parsed = int.Parse(newVal);
+                            long parsed = long.Parse(newVal);
                             if (parsed == -1)
                             {
-                                int max = (int)type.Max;
-                                parsed = Random.Shared.Next(0, max <= 0 ? int.MaxValue : max);
+                                long max = (long)type.Max;
+                                parsed = Random.Shared.NextInt64(0, max <= 0 ? long.MaxValue : max);
                             }
                             return parsed.ToString();
                         }
@@ -224,10 +224,10 @@ public class ComfyUIBackendExtension : Extension
                     nameNoPrefix = nameNoPrefix.After("seed");
                     string seedClean(string prior, string newVal)
                     {
-                        int parsed = int.Parse(newVal);
+                        long parsed = long.Parse(newVal);
                         if (parsed == -1)
                         {
-                            parsed = Random.Shared.Next(0, int.MaxValue);
+                            parsed = Random.Shared.NextInt64(0, long.MaxValue);
                         }
                         return parsed.ToString();
                     }
@@ -417,7 +417,7 @@ public class ComfyUIBackendExtension : Extension
     }
 
     public static LockObject ValueAssignmentLocker = new();
-    
+
     /// <summary>Add handlers here to do additional parsing of RawObjectInfo data.</summary>
     public static List<Action<JObject>> RawObjectInfoParsers = [];
 

--- a/src/BuiltinExtensions/GridGenerator/GridGenCore.cs
+++ b/src/BuiltinExtensions/GridGenerator/GridGenCore.cs
@@ -67,10 +67,10 @@ public partial class GridGenCore
                 {
                     throw new SwarmReadableErrorException($"Cannot use ellipses notation at index {i}/{inList.Count} - must have at least 2 values before and 1 after.");
                 }
-                double prior = double.Parse(outList[^1].Replace("SKIP:", ""));
-                double doublePrior = double.Parse(outList[^2].Replace("SKIP:", ""));
-                double after = double.Parse(inList[i + 1]);
-                double step = prior - doublePrior;
+                decimal prior = decimal.Parse(outList[^1].Replace("SKIP:", ""));
+                decimal doublePrior = decimal.Parse(outList[^2].Replace("SKIP:", ""));
+                decimal after = decimal.Parse(inList[i + 1]);
+                decimal step = prior - doublePrior;
                 if ((step < 0) != ((after - prior) < 0))
                 {
                     throw new SwarmReadableErrorException($"Ellipses notation failed for step {step} between {prior} and {after} - steps backwards.");
@@ -78,10 +78,14 @@ public partial class GridGenCore
                 int count = (int)Math.Round((after - prior) / step);
                 for (int x = 1; x < count; x++)
                 {
-                    double outVal = prior + x * step;
+                    decimal outVal = prior + x * step;
                     if (numType == typeof(int))
                     {
                         outVal = (int)Math.Round(outVal);
+                    }
+                    else if (numType == typeof(long))
+                    {
+                        outVal = (long)Math.Round(outVal);
                     }
                     outList.Add($"{prefix}{outVal:0.#######}");
                 }
@@ -174,7 +178,7 @@ public partial class GridGenCore
             }
             if (Mode.Type == T2IParamDataType.INTEGER)
             {
-                valuesList = ExpandNumericListRanges(valuesList, typeof(int));
+                valuesList = ExpandNumericListRanges(valuesList, typeof(long));
             }
             else if (Mode.Type == T2IParamDataType.DECIMAL)
             {


### PR DESCRIPTION
The `T2IParamDataType.INTEGER` parameter corresponds to Python’s integer type, not C#’s `int32`.
To accommodate larger numbers when passing values in C#, some parts of the code already treat it as a `long`.

For example:
In `T2IParamSet.cs`:
```csharp
object obj = param.Type switch
{
    T2IParamDataType.INTEGER => param.SharpType == typeof(long) ? long.Parse(val) : int.Parse(val),
```

In `T2IParamType.cs`:
```csharp
public static Type DataTypeToSharpType(T2IParamDataType t)
{
    return t switch {
        T2IParamDataType.INTEGER => typeof(long),
```

However, in both `ComfyUIBackendExtension.cs` and `ComfyUIAPIAbstractBackend.cs`, the received parameters were being cast to `int32`, causing parse failures when users input large numbers.
A common scenario is when a user wants to reuse the seed from an existing image, which can often be a 14–16 digit number—too large to fit in `int32`, and therefore not accepted by `SwarmInputInteger`.

This commit updates all relevant usages of `T2IParamDataType.INTEGER` to use `long`, and verifies that `SwarmInputInteger` can now successfully pass a 16 digit number seed.
