### PR TITLE
Add finalization handlers for prompt preprocessing steps

### DIFF
--- a/src/BuiltinExtensions/ComfyUIBackend/ComfyUIWebAPI.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/ComfyUIWebAPI.cs
@@ -141,6 +141,7 @@ public static class ComfyUIWebAPI
             input = T2IAPI.RequestToParams(session, rawInput);
             input.ApplySpecialLogic();
             input.PreparsePromptLikes();
+            await input.ApplyPreparsePromptLikesFinalizationHandlers();
             ComfyUIAPIAbstractBackend backend = ComfyUIBackendExtension.ComfyBackendsDirect().FirstOrDefault().Backend as ComfyUIAPIAbstractBackend;
             if (backend is null)
             {

--- a/src/Text2Image/T2IEngine.cs
+++ b/src/Text2Image/T2IEngine.cs
@@ -239,6 +239,7 @@ namespace SwarmUI.Text2Image
             try
             {
                 user_input.PreparsePromptLikes();
+                await user_input.ApplyPreparsePromptLikesFinalizationHandlers();
                 PreGenerateEvent?.Invoke(new(user_input));
                 claim.Extend(backendWaits: 1);
                 sendStatus();

--- a/src/Text2Image/T2IParamInput.cs
+++ b/src/Text2Image/T2IParamInput.cs
@@ -30,6 +30,9 @@ public class T2IParamInput
             Set(T2IParamTypes.VariationSeed, Random.Shared.Next());
         }
     }
+    
+    /// <summary>Extension point for injecting code to examine or modify inputs after the prompt has been parsed but before it is sent to the backend.</summary>
+    public static List<Func<T2IParamInput, Task>> PreparsePromptLikesFinalizationHandlers = [];
 
     /// <summary>Special handlers for any special logic to apply post-loading a param input.</summary>
     public static List<Action<T2IParamInput>> SpecialParameterHandlers =
@@ -578,6 +581,14 @@ public class T2IParamInput
     public void Remove(T2IParamType param)
     {
         InternalSet.Remove(param);
+    }
+    
+    public async Task ApplyPreparsePromptLikesFinalizationHandlers()
+    {
+        foreach (Func<T2IParamInput, Task> handler in PreparsePromptLikesFinalizationHandlers)
+        {
+            await handler(this);
+        }
     }
 
     /// <summary>Makes sure the input has valid seed inputs and other special parameter handlers.</summary>


### PR DESCRIPTION
This is not needed by the Core application but acts as an extension point for Extensions that want to manipulate the input params after all of the wildcard, random, and other prompt-modification tags have been processed.

I was previously hooking into the pipeline in a wonky way (via the `PreGenerateEvent` event) but that event only fired during generation and there was no equivalent way to hook into the process when clicking the "Generate Workflow from Generator tab" button on Comfy tab.   Also some of the processing I wanted to run was async and I felt bad everytime I wrote `Task.Result` to block until the task completed.
