### PR TITLE
Small UI Improvements

### DIFF
--- a/src/wwwroot/css/genpage.css
+++ b/src/wwwroot/css/genpage.css
@@ -220,6 +220,7 @@ body {
     min-width: 20rem;
     vertical-align: top;
     margin-left: 0.5rem;
+    margin-right: 0.5rem;
     max-height: 10rem;
 }
 .extras-wrapper-sideblock .current-image-data {
@@ -391,6 +392,7 @@ body {
 .model-block img {
     max-height: 9rem;
     width: 9rem;
+    height: 9rem;
     display: inline-block;
     margin: 0.5rem;
     margin-bottom: 0px;
@@ -436,10 +438,12 @@ body {
 .model-block-small img {
     max-height: 7rem;
     width: 7rem;
+    height: 7rem;
 }
 .model-block-big img {
     max-height: 14rem;
     width: 14rem;
+    height: 14rem;
 }
 .model-block-menu-button {
     display: block;
@@ -669,6 +673,8 @@ body {
     border: 1px solid var(--light-border);
     display: inline-block;
     color: var(--text-soft);
+    overflow: clip;
+    text-overflow: ellipsis;
 }
 .param_view_block_model {
     background-color: color-mix(in srgb, transparent 99%, var(--tag-color));

--- a/src/wwwroot/css/site.css
+++ b/src/wwwroot/css/site.css
@@ -154,6 +154,8 @@ body {
 }
 .card-body {
     background-color: var(--background);
+    border-bottom-left-radius: 5px;
+    border-bottom-right-radius: 5px;
 }
 .backend-errored .card-header {
     background-color: var(--background-gray-danger);


### PR DESCRIPTION
* Card body no longer clips the card border (rounded bottom card body corners)  
  <img width="1503" height="447" alt="image" src="https://github.com/user-attachments/assets/7d0b13af-7e90-493f-b458-2839aab1ab09" />

* Image info (image extras) no longer has 0 margin to the right  
  <img width="2906" height="1907" alt="image" src="https://github.com/user-attachments/assets/cdc14e57-1626-4292-a6a8-0a459348afaa" />  
  The view with the image next to the image info (image extras) should not be affected, at least it wasn't in my testing.  
* Image extras param blocks can no longer overflow text, instead clipping it and displaying ellipses  
  <img width="2104" height="1646" alt="image" src="https://github.com/user-attachments/assets/81a303ae-9c6d-4aef-8a78-b4cee6074a96" />  
  In my testing it only has an effect if you are in the view mode where the image info (image extras) and the image are next to each other, as it seems like it already properly cuts off the text when in the view mode where the image is above the image info.  
* Model block images (Small Card, Card, Big Card) are now centered  
  Small Cards:  
  <img width="1344" height="2187" alt="image" src="https://github.com/user-attachments/assets/fc0941b0-402d-4569-a758-fce6bef3a7fd" />  
  Regular Cards:  
  <img width="1344" height="2187" alt="image" src="https://github.com/user-attachments/assets/4e5c36f5-727a-4da4-90f5-2cd951548ad6" />  
  Big Cards:  
  <img width="1344" height="2187" alt="image" src="https://github.com/user-attachments/assets/00757ae0-0f70-43cd-abc9-2cebdb4bc049" />