### PR TITLE
fix: remove duplicate usage_hint assignment in ModelMetadataScanner

### DIFF
--- a/src/wwwroot/js/genpage/utiltab.js
+++ b/src/wwwroot/js/genpage/utiltab.js
@@ -827,7 +827,6 @@ class ModelMetadataScanner {
                             'description': model.description || '',
                             'standard_width': model.standard_width || 0,
                             'standard_height': model.standard_height || 0,
-                            'usage_hint': model.usage_hint || '',
                             'date': model.date || '',
                             'license': model.license || '',
                             'trigger_phrase': model.trigger_phrase || '',


### PR DESCRIPTION
## Overview
Fixed an issue where `usage_hint` was being set multiple times in the `ModelMetadataScanner` class.

https://github.com/mcmonkeyprojects/SwarmUI/blob/a50ab92c1365d06229bee9b7a2186f2cd22c027f/src/wwwroot/js/genpage/utiltab.js#L830-L834