### PR TITLE
fix: display position shift caused by scrollbars

### DIFF
--- a/src/wwwroot/css/genpage.css
+++ b/src/wwwroot/css/genpage.css
@@ -403,6 +403,7 @@ body {
     width: 19.5rem;
     height: 10rem;
     overflow: hidden;
+    scrollbar-gutter: stable;
     display: inline-block;
     white-space: normal;
     word-break: normal;


### PR DESCRIPTION
Fixes the shifting of internal elements when clicking elements such as model cards.


### Behavior before the change
When not focused:
<img width="321" height="162" alt="スクリーンショット 2025-08-23 9 01 40" src="https://github.com/user-attachments/assets/5d9cef44-9916-4b08-b52a-cfddd5b8d7e4" />

On focus (The text "eyes" has moved to the next line.): 
<img width="323" height="160" alt="スクリーンショット 2025-08-23 9 01 48" src="https://github.com/user-attachments/assets/1c1a25a0-c893-4979-b50f-e886133bfd67" />