### PR TITLE
Add advanced image history filtering and architecture grouping

### DIFF
--- a/src/Pages/_Generate/GenTabModals.cshtml
+++ b/src/Pages/_Generate/GenTabModals.cshtml
@@ -135,6 +135,7 @@
                 <option value="@arch.ID" class="translate">@arch.Name</option>
             }
         </select></div>
+        <div>Architecture Group: <input type="text" id="edit_model_architecture_group" class="modal_text_extra translate" placeholder="Custom Architecture group for Image History" /></div>
         <div>Prediction Type: <select id="edit_model_prediction_type" class="modal_text_extra translate" placeholder="Model Type">
             <option value="">Unspecified</option><option value="v">V-Prediction</option><option value="epsilon">Epsilon</option><option value="x0">x0</option><option value="lcm">LCM</option><option value="v-zsnr">VPred ZSNR</option>
         </select></div>

--- a/src/Text2Image/T2IModel.cs
+++ b/src/Text2Image/T2IModel.cs
@@ -219,6 +219,7 @@ public class T2IModel(T2IModelHandler handler, string folderPath, string filePat
                 specSetEmptyable("trigger_phrase", Metadata.TriggerPhrase);
                 specSetEmptyable("tags", Metadata.Tags is null ? null : string.Join(",", Metadata.Tags));
                 specSet("merged_from", Metadata.MergedFrom);
+                specSet("architecture_group", Metadata.ArchitectureGroup);
                 specSet("date", Metadata.Date);
                 specSet("preprocessor", Metadata.Preprocessor);
                 specSet("resolution", $"{Metadata.StandardWidth}x{Metadata.StandardHeight}");
@@ -304,6 +305,7 @@ public class T2IModel(T2IModelHandler handler, string folderPath, string filePat
             [$"{prefix}usage_hint"] = Metadata?.UsageHint,
             [$"{prefix}trigger_phrase"] = Metadata?.TriggerPhrase,
             [$"{prefix}merged_from"] = Metadata?.MergedFrom,
+            [$"{prefix}architecture_group"] = Metadata?.ArchitectureGroup,
             [$"{prefix}tags"] = Metadata?.Tags is null ? null : new JArray(Metadata.Tags),
             [$"{prefix}is_supported_model_format"] = IsSupportedModelType,
             [$"{prefix}is_negative_embedding"] = Metadata?.IsNegativeEmbedding ?? false,

--- a/src/Text2Image/T2IModelHandler.cs
+++ b/src/Text2Image/T2IModelHandler.cs
@@ -117,6 +117,8 @@ public class T2IModelHandler
 
         public string MergedFrom { get; set; }
 
+        public string ArchitectureGroup { get; set; }
+
         public string Date { get; set; }
 
         public string Preprocessor { get; set; }
@@ -658,6 +660,7 @@ public class T2IModelHandler
                 StandardHeight = height,
                 UsageHint = pickBest(metaHeader?.Value<string>("modelspec.usage_hint"), metaHeader?.Value<string>("usage_hint")),
                 MergedFrom = pickBest(metaHeader?.Value<string>("modelspec.merged_from"), metaHeader?.Value<string>("merged_from")),
+                ArchitectureGroup = pickBest(metaHeader?.Value<string>("modelspec.architecture_group"), metaHeader?.Value<string>("architecture_group")),
                 TriggerPhrase = pickBest(metaHeader?.Value<string>("modelspec.trigger_phrase"), metaHeader?.Value<string>("trigger_phrase")) ?? altTriggerPhrase,
                 License = pickBest(metaHeader?.Value<string>("modelspec.license"), metaHeader?.Value<string>("license")),
                 Date = pickBest(metaHeader?.Value<string>("modelspec.date"), metaHeader?.Value<string>("date")),

--- a/src/WebAPI/ModelsAPI.cs
+++ b/src/WebAPI/ModelsAPI.cs
@@ -464,6 +464,8 @@ public static class ModelsAPI
         [API.APIParameter("New model `trigger_phrase` metadata value.")] string trigger_phrase,
         [API.APIParameter("New model `prediction_type` metadata value.")] string prediction_type,
         [API.APIParameter("New model `tags` metadata value (comma-separated list).")] string tags,
+        [API.APIParameter("New model `merged_from` metadata value.")] string merged_from,
+        [API.APIParameter("New model `architecture_group` metadata value.")] string architecture_group,
         [API.APIParameter("New model `preview_image` metadata value (image-data-string format, or null to not change).")] string preview_image = null,
         [API.APIParameter("Optional raw text of metadata to inject to the preview image.")] string preview_image_metadata = null,
         [API.APIParameter("New model `is_negative_embedding` metadata value.")] bool is_negative_embedding = false,
@@ -516,6 +518,8 @@ public static class ModelsAPI
             actualModel.Metadata.Tags = string.IsNullOrWhiteSpace(tags) ? null : tags.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
             actualModel.Metadata.IsNegativeEmbedding = is_negative_embedding;
             actualModel.Metadata.PredictionType = string.IsNullOrWhiteSpace(prediction_type) ? null : prediction_type;
+            actualModel.Metadata.MergedFrom = string.IsNullOrWhiteSpace(merged_from) ? null : merged_from;
+            actualModel.Metadata.ArchitectureGroup = string.IsNullOrWhiteSpace(architecture_group) ? null : architecture_group;
         }
         handler.ResetMetadataFrom(actualModel);
         _ = Utilities.RunCheckedTask(() => actualModel.ResaveModel(), "model resave");

--- a/src/wwwroot/js/genpage/gentab/imagehistory.js
+++ b/src/wwwroot/js/genpage/gentab/imagehistory.js
@@ -1,5 +1,10 @@
 
+if (typeof modelArchitectureMap === 'undefined') {
+    window.modelArchitectureMap = {};
+}
+
 function listImageHistoryFolderAndFiles(path, isRefresh, callback, depth) {
+    availableArchitectures.clear();
     let sortBy = localStorage.getItem('image_history_sort_by') ?? 'Name';
     let reverse = localStorage.getItem('image_history_sort_reverse') == 'true';
     let allowAnims = localStorage.getItem('image_history_allow_anims') != 'false';
@@ -127,6 +132,244 @@ function buttonsForImage(fullsrc, src, metadata) {
     return buttons;
 }
 
+function parseSearchQuery(query) {
+    const namespaces = ['lora', 'prompt', 'model', 'controlnet', 'seed', 'steps', 'cfgscale', 'aspectratio', 'width', 'height', 'sampler', 'videoframes', 'fps', 'date'];
+    const parts = [];
+    let remaining = query.toLowerCase();
+    
+    while (remaining.length > 0) {
+        let matched = false;
+        for (let ns of namespaces) {
+            if (remaining.startsWith(ns + ':')) {
+                const afterColon = remaining.substring(ns.length + 1);
+                let value = '';
+                let inQuotes = false;
+                let i = 0;
+                
+                for (; i < afterColon.length; i++) {
+                    const char = afterColon[i];
+                    if (char === '"') {
+                        inQuotes = !inQuotes;
+                    } else if (!inQuotes && char === ' ') {
+                        break;
+                    } else {
+                        value += char;
+                    }
+                }
+                
+                parts.push({ type: 'namespace', namespace: ns, value: value.trim() });
+                remaining = afterColon.substring(i).trim();
+                matched = true;
+                break;
+            }
+        }
+        
+        if (!matched) {
+            const spaceIndex = remaining.indexOf(' ');
+            if (spaceIndex === -1) {
+                if (remaining.length > 0) {
+                    parts.push({ type: 'text', value: remaining });
+                }
+                break;
+            } else {
+                parts.push({ type: 'text', value: remaining.substring(0, spaceIndex) });
+                remaining = remaining.substring(spaceIndex + 1).trim();
+            }
+        }
+    }
+    
+    return parts;
+}
+
+function matchesNamespaceSearch(parsedMeta, namespace, searchValue) {
+    const params = parsedMeta.sui_image_params || {};
+    
+    switch(namespace) {
+        case 'prompt':
+            return (params.prompt || '').toLowerCase().includes(searchValue);
+        
+        case 'lora': {
+            const promptLoras = [];
+            const prompt = (params.prompt || '').toLowerCase();
+            const loraMatches = prompt.matchAll(/<lora:([^:>]+):[^>]+>/g);
+            for (const match of loraMatches) {
+                promptLoras.push(match[1].toLowerCase());
+            }
+            
+            const loraHashes = params.lorahashesinprompt || [];
+            const loraNames = params.loranamesinprompt || [];
+            const allLoras = [...promptLoras, ...loraHashes, ...loraNames].map(l => l.toLowerCase());
+            
+            if (parsedMeta.sui_models) {
+                for (const model of parsedMeta.sui_models) {
+                    if (model.param === 'lora' && model.name) {
+                        allLoras.push(model.name.toLowerCase());
+                    }
+                }
+            }
+            
+            return allLoras.some(lora => lora.includes(searchValue));
+        }
+        
+        case 'model':
+            return (params.model || '').toLowerCase().includes(searchValue);
+        
+        case 'controlnet': {
+            const controlnets = params.controlnets || [];
+            const cnFound = controlnets.some(cn => (cn.model || '').toLowerCase().includes(searchValue));
+            
+            if (!cnFound && parsedMeta.sui_models) {
+                for (const model of parsedMeta.sui_models) {
+                    if (model.param === 'controlnet' && model.name) {
+                        if (model.name.toLowerCase().includes(searchValue)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+            
+            return cnFound;
+        }
+        
+        case 'seed': {
+            const seedValue = params.seed;
+            if (seedValue === undefined || seedValue === null) return false;
+            
+            if (searchValue.startsWith('>')) {
+                return parseInt(seedValue) > parseInt(searchValue.substring(1).trim());
+            } else if (searchValue.startsWith('<')) {
+                return parseInt(seedValue) < parseInt(searchValue.substring(1).trim());
+            } else if (searchValue.startsWith('=')) {
+                return seedValue.toString() === searchValue.substring(1).trim();
+            } else {
+                return seedValue.toString().includes(searchValue);
+            }
+        }
+        
+        case 'steps': {
+            const stepsValue = params.steps;
+            if (stepsValue === undefined || stepsValue === null) return false;
+            
+            if (searchValue.startsWith('>')) {
+                return parseInt(stepsValue) > parseInt(searchValue.substring(1).trim());
+            } else if (searchValue.startsWith('<')) {
+                return parseInt(stepsValue) < parseInt(searchValue.substring(1).trim());
+            } else if (searchValue.startsWith('=')) {
+                return stepsValue.toString() === searchValue.substring(1).trim();
+            } else {
+                return stepsValue.toString() === searchValue;
+            }
+        }
+        
+        case 'cfgscale': {
+            const cfgValue = params.cfgscale;
+            if (cfgValue === undefined || cfgValue === null) return false;
+            
+            if (searchValue.startsWith('>')) {
+                return parseFloat(cfgValue) > parseFloat(searchValue.substring(1).trim());
+            } else if (searchValue.startsWith('<')) {
+                return parseFloat(cfgValue) < parseFloat(searchValue.substring(1).trim());
+            } else if (searchValue.startsWith('=')) {
+                return parseFloat(cfgValue) === parseFloat(searchValue.substring(1).trim());
+            } else {
+                return cfgValue.toString() === searchValue;
+            }
+        }
+        
+        case 'aspectratio':
+            return (params.aspectratio || '').toLowerCase().includes(searchValue);
+        
+        case 'width': {
+            const widthValue = params.width;
+            if (widthValue === undefined || widthValue === null) return false;
+            
+            if (searchValue.startsWith('>')) {
+                return parseInt(widthValue) > parseInt(searchValue.substring(1).trim());
+            } else if (searchValue.startsWith('<')) {
+                return parseInt(widthValue) < parseInt(searchValue.substring(1).trim());
+            } else if (searchValue.startsWith('=')) {
+                return widthValue.toString() === searchValue.substring(1).trim();
+            } else {
+                return widthValue.toString() === searchValue;
+            }
+        }
+        
+        case 'height': {
+            const heightValue = params.height;
+            if (heightValue === undefined || heightValue === null) return false;
+            
+            if (searchValue.startsWith('>')) {
+                return parseInt(heightValue) > parseInt(searchValue.substring(1).trim());
+            } else if (searchValue.startsWith('<')) {
+                return parseInt(heightValue) < parseInt(searchValue.substring(1).trim());
+            } else if (searchValue.startsWith('=')) {
+                return heightValue.toString() === searchValue.substring(1).trim();
+            } else {
+                return heightValue.toString() === searchValue;
+            }
+        }
+        
+        case 'sampler':
+            return (params.sampler || '').toLowerCase().includes(searchValue);
+        
+        case 'videoframes': {
+            const framesValue = params.videoframes;
+            if (framesValue === undefined || framesValue === null) return false;
+            
+            if (searchValue.startsWith('>')) {
+                return parseInt(framesValue) > parseInt(searchValue.substring(1).trim());
+            } else if (searchValue.startsWith('<')) {
+                return parseInt(framesValue) < parseInt(searchValue.substring(1).trim());
+            } else if (searchValue.startsWith('=')) {
+                return framesValue.toString() === searchValue.substring(1).trim();
+            } else {
+                return framesValue.toString() === searchValue;
+            }
+        }
+        
+        case 'fps': {
+            const fpsValue = params.videofps;
+            if (fpsValue === undefined || fpsValue === null) return false;
+            
+            if (searchValue.startsWith('>')) {
+                return parseInt(fpsValue) > parseInt(searchValue.substring(1).trim());
+            } else if (searchValue.startsWith('<')) {
+                return parseInt(fpsValue) < parseInt(searchValue.substring(1).trim());
+            } else if (searchValue.startsWith('=')) {
+                return fpsValue.toString() === searchValue.substring(1).trim();
+            } else {
+                return fpsValue.toString() === searchValue;
+            }
+        }
+        
+        case 'date': {
+            const dateStr = parsedMeta.sui_extra_data?.date || params.date || parsedMeta.date || '';
+            if (!dateStr) return false;
+            
+            const fileDate = dateStr.replace(/-/g, '.');
+            const [fileYear, fileMonth] = fileDate.split('.');
+            const fileYearMonth = `${fileYear}.${fileMonth}`;
+            
+            if (searchValue.startsWith('>')) {
+                const compareDate = searchValue.substring(1).trim().replace(/-/g, '.');
+                return fileDate > compareDate;
+            } else if (searchValue.startsWith('<')) {
+                const compareDate = searchValue.substring(1).trim().replace(/-/g, '.');
+                return fileDate < compareDate;
+            } else if (searchValue.startsWith('=')) {
+                const compareDate = searchValue.substring(1).trim().replace(/-/g, '.');
+                return fileDate === compareDate || fileYear === compareDate || fileYearMonth === compareDate;
+            } else {
+                const searchDate = searchValue.replace(/-/g, '.');
+                return fileDate.includes(searchDate) || fileYear === searchDate || fileYearMonth === searchDate;
+            }
+        }
+        
+        default:
+            return false;
+    }
+}
+
 function describeImage(image) {
     let buttons = buttonsForImage(image.data.fullsrc, image.data.src, image.data.metadata);
     let parsedMeta = { is_starred: false };
@@ -140,6 +383,86 @@ function describeImage(image) {
             console.log(`Failed to parse image metadata: ${e}, metadata was ${metadata}`);
         }
     }
+    
+    parsedMeta.originalFilename = image.data.name;
+    
+    let fullModelName = null;
+    if (parsedMeta.sui_models) {
+        const mainModel = parsedMeta.sui_models.find(m => m.param === 'model');
+        if (mainModel && mainModel.name) {
+            fullModelName = mainModel.name;
+        }
+    }
+    
+    if (!fullModelName) {
+        const shortName = parsedMeta.sui_image_params?.model || parsedMeta.model || null;
+        if (shortName) {
+            fullModelName = shortName.includes('.') ? shortName : shortName + '.safetensors';
+        }
+    }
+    
+    let groupedArch = null;
+    if (fullModelName && typeof modelArchitectureMap !== 'undefined') {
+        groupedArch = modelArchitectureMap[fullModelName];
+        
+        if (!groupedArch && fullModelName.includes('/')) {
+            const filename = fullModelName.split('/').pop();
+            groupedArch = modelArchitectureMap[filename];
+            
+            if (!groupedArch) {
+                for (let modelKey in modelArchitectureMap) {
+                    if (modelKey.endsWith('/' + filename) || modelKey === filename) {
+                        groupedArch = modelArchitectureMap[modelKey];
+                        break;
+                    }
+                }
+            }
+        }
+        
+        if (!groupedArch && !fullModelName.includes('.')) {
+            const modelNameWithExt = fullModelName + '.safetensors';
+            groupedArch = modelArchitectureMap[modelNameWithExt];
+        }
+        
+        if (!groupedArch) {
+            groupedArch = 'Unknown';
+        }
+    }
+    
+    if (groupedArch) {
+        availableArchitectures.add(groupedArch);
+    }
+    
+    if (architectureFilterState !== 'all' && architectureFilterState !== groupedArch) {
+        return null;
+    }
+    
+    if (mediaTypeFilterState !== 'all') {
+        const filename = image.data.name || image.data.fullsrc || '';
+        const ext = filename.split('.').pop().toLowerCase();
+        const frames = parsedMeta.sui_image_params?.videoframes || 1;
+        
+        const isVideo = isVideoExt(filename) || 
+                       (ext === 'gif' && frames > 1) || 
+                       (ext === 'webp' && frames > 1);
+        
+        if (mediaTypeFilterState === 'videos' && !isVideo) return null;
+        if (mediaTypeFilterState === 'images' && isVideo) return null;
+    }
+    
+    if (orientationFilterState !== 'all' && parsedMeta.sui_image_params?.width && parsedMeta.sui_image_params?.height) {
+        const width = parsedMeta.sui_image_params.width;
+        const height = parsedMeta.sui_image_params.height;
+        const aspectRatio = width / height;
+        
+        if (orientationFilterState === 'portrait' && aspectRatio >= 1) return null;
+        if (orientationFilterState === 'landscape' && aspectRatio <= 1) return null;
+        if (orientationFilterState === 'square') {
+            const tolerance = 0.15;
+            if (Math.abs(aspectRatio - 1) > tolerance) return null;
+        }
+    }
+    
     let formattedMetadata = formatMetadata(image.data.metadata);
     let description = image.data.name + "\n" + formattedMetadata;
     let name = image.data.name;
@@ -150,7 +473,7 @@ function describeImage(image) {
     let searchable = `${image.data.name}, ${image.data.metadata}, ${image.data.fullsrc}`;
     let detail_list = [escapeHtml(image.data.name), formattedMetadata.replaceAll('<br>', '&emsp;')];
     let aspectRatio = parsedMeta.sui_image_params?.width && parsedMeta.sui_image_params?.height ? parsedMeta.sui_image_params.width / parsedMeta.sui_image_params.height : null;
-    return { name, description, buttons, 'image': imageSrc, 'dragimage': dragImage, className: parsedMeta.is_starred ? 'image-block-starred' : '', searchable, display: name, detail_list, aspectRatio };
+    return { name, description, buttons, 'image': imageSrc, 'dragimage': dragImage, className: parsedMeta.is_starred ? 'image-block-starred' : '', searchable, display: name, detail_list, aspectRatio, parsedMeta };
 }
 
 function selectImageInHistory(image, div) {
@@ -174,8 +497,115 @@ function selectImageInHistory(image, div) {
     }
 }
 
+let orientationFilterState = localStorage.getItem('image_history_orientation_filter') || 'all';
+let mediaTypeFilterState = localStorage.getItem('image_history_media_type_filter') || 'all';
+let architectureFilterState = localStorage.getItem('image_history_architecture_filter') || 'all';
+let availableArchitectures = new Set();
+
+function getArchitectureDropdown() {
+    let options = ['<option value="all">All</option>'];
+    
+    const allArchitectures = new Set();
+    if (typeof modelArchitectureMap !== 'undefined') {
+        for (let model in modelArchitectureMap) {
+            const arch = modelArchitectureMap[model];
+            if (arch && arch !== 'Unknown') {
+                allArchitectures.add(arch);
+            }
+        }
+    }
+    
+    for (let arch of availableArchitectures) {
+        if (arch && arch !== 'Unknown') {
+            allArchitectures.add(arch);
+        }
+    }
+    
+    const sortedArchs = Array.from(allArchitectures).sort();
+    for (let arch of sortedArchs) {
+        const selected = arch === architectureFilterState ? ' selected' : '';
+        options.push(`<option value="${escapeHtml(arch)}"${selected}>${escapeHtml(arch)}</option>`);
+    }
+    
+    if (typeof modelArchitectureMap !== 'undefined' && Object.values(modelArchitectureMap).includes('Unknown')) {
+        const selected = 'Unknown' === architectureFilterState ? ' selected' : '';
+        options.push(`<option value="Unknown"${selected}>Unknown</option>`);
+    }
+    
+    return `<label for="image_history_arch_filter">Arch:</label> <select id="image_history_arch_filter" onchange="setArchitectureFilter(this.value)" style="margin-right: 8px;">${options.join('')}</select>`;
+}
+
+function setArchitectureFilter(arch) {
+    architectureFilterState = arch;
+    localStorage.setItem('image_history_architecture_filter', arch);
+    imageHistoryBrowser.update();
+}
+
+function getOrientationFilterButtons() {
+    const portraitSvg = '<svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor"><rect x="5" y="2" width="10" height="16" stroke="currentColor" fill="none" stroke-width="1.5"/></svg>';
+    const landscapeSvg = '<svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor"><rect x="2" y="5" width="16" height="10" stroke="currentColor" fill="none" stroke-width="1.5"/></svg>';
+    const squareSvg = '<svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor"><rect x="3" y="3" width="14" height="14" stroke="currentColor" fill="none" stroke-width="1.5"/></svg>';
+    const imageSvg = '<svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor"><rect x="3" y="5" width="14" height="10" stroke="currentColor" fill="none" stroke-width="1.5"/><circle cx="7" cy="9" r="1.5" fill="currentColor"/><path d="M3 13l4-3 3 2 7-5" stroke="currentColor" fill="none" stroke-width="1.2"/></svg>';
+    const videoSvg = '<svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor"><rect x="2" y="5" width="12" height="10" stroke="currentColor" fill="none" stroke-width="1.5"/><path d="M14 10l5-3v6z" fill="currentColor"/></svg>';
+    
+    return `<button id="orientation_portrait" class="orientation-filter-btn basic-button" title="Portrait" onclick="setOrientationFilter('portrait')" style="padding: 2px 6px; margin-right: 4px;">${portraitSvg}</button>`
+        + `<button id="orientation_landscape" class="orientation-filter-btn basic-button" title="Landscape" onclick="setOrientationFilter('landscape')" style="padding: 2px 6px; margin-right: 4px;">${landscapeSvg}</button>`
+        + `<button id="orientation_square" class="orientation-filter-btn basic-button" title="Square" onclick="setOrientationFilter('square')" style="padding: 2px 6px; margin-right: 8px;">${squareSvg}</button>`
+        + `<span style="border-left: 1px solid #666; margin: 0 8px; padding: 0; height: 20px; display: inline-block; vertical-align: middle;"></span>`
+        + `<button id="media_images" class="media-filter-btn basic-button" title="Images" onclick="setMediaTypeFilter('images')" style="padding: 2px 6px; margin-right: 4px;">${imageSvg}</button>`
+        + `<button id="media_videos" class="media-filter-btn basic-button" title="Videos" onclick="setMediaTypeFilter('videos')" style="padding: 2px 6px; margin-right: 8px;">${videoSvg}</button>`;
+}
+
+function setOrientationFilter(orientation) {
+    orientationFilterState = orientationFilterState === orientation ? 'all' : orientation;
+    localStorage.setItem('image_history_orientation_filter', orientationFilterState);
+    updateFilterButtons();
+    imageHistoryBrowser.update();
+}
+
+function setMediaTypeFilter(mediaType) {
+    mediaTypeFilterState = mediaTypeFilterState === mediaType ? 'all' : mediaType;
+    localStorage.setItem('image_history_media_type_filter', mediaTypeFilterState);
+    updateFilterButtons();
+    imageHistoryBrowser.update();
+}
+
+function updateFilterButtons() {
+    document.querySelectorAll('.orientation-filter-btn').forEach(btn => {
+        btn.style.opacity = '0.5';
+    });
+    if (orientationFilterState !== 'all') {
+        const activeBtn = document.getElementById(`orientation_${orientationFilterState}`);
+        if (activeBtn) activeBtn.style.opacity = '1';
+    }
+    
+    document.querySelectorAll('.media-filter-btn').forEach(btn => {
+        btn.style.opacity = '0.5';
+    });
+    if (mediaTypeFilterState !== 'all') {
+        const activeBtn = document.getElementById(`media_${mediaTypeFilterState}`);
+        if (activeBtn) activeBtn.style.opacity = '1';
+    }
+}
+
 let imageHistoryBrowser = new GenPageBrowserClass('image_history', listImageHistoryFolderAndFiles, 'imagehistorybrowser', 'Thumbnails', describeImage, selectImageInHistory,
-    `<label for="image_history_sort_by">Sort:</label> <select id="image_history_sort_by"><option>Name</option><option>Date</option></select> <input type="checkbox" id="image_history_sort_reverse"> <label for="image_history_sort_reverse">Reverse</label> &emsp; <input type="checkbox" id="image_history_allow_anims" checked autocomplete="off"> <label for="image_history_allow_anims">Allow Animation</label>`);
+    '<span id="arch_dropdown_container"></span>' + getOrientationFilterButtons() + `<label for="image_history_sort_by">Sort:</label> <select id="image_history_sort_by"><option>Name</option><option>Date</option></select> <input type="checkbox" id="image_history_sort_reverse"> <label for="image_history_sort_reverse">Reverse</label> &emsp; <input type="checkbox" id="image_history_allow_anims" checked autocomplete="off"> <label for="image_history_allow_anims">Allow Animation</label>`);
+
+setTimeout(() => {
+    updateFilterButtons();
+    updateArchitectureDropdown();
+}, 100);
+
+function updateArchitectureDropdown() {
+    setTimeout(() => {
+        const container = document.getElementById('arch_dropdown_container');
+        if (container) {
+            container.innerHTML = getArchitectureDropdown();
+        }
+    }, 500);
+}
+
+imageHistoryBrowser.builtEvent = updateArchitectureDropdown;
 
 function storeImageToHistoryWithCurrentParams(img) {
     let data = getGenInput();


### PR DESCRIPTION
Adds:
• namespace-based search filtering
• orientation filtering
• image/video filtering <-- uses your video extension function, with a fallback to frame count parameter, for things like .webp or .gif
• architecture filtering

• automatic arch group detection based on model names (needs to be maintained if new model groups get released, that you actually care about)
• optional "Architecture Group" override in the model metadata. (relevant if you do subgroups for specific model series like the pony models or illustrious models)

<img width="1850" height="383" alt="image" src="https://github.com/user-attachments/assets/1b2f06f1-e419-49d9-bd43-dbb0949ca6f1" />
<img width="584" height="733" alt="image" src="https://github.com/user-attachments/assets/fad03430-3786-460d-9777-f697f63e4c5d" />
<img width="422" height="275" alt="image" src="https://github.com/user-attachments/assets/1a47d49d-5ab6-414c-a2bc-fd8253732f74" />
<img width="559" height="692" alt="image" src="https://github.com/user-attachments/assets/fc41d509-2a88-457e-b68b-106cb92b47b6" />
