### PR TITLE
fix: load LoRA weight/confinement in model edit

### DIFF
--- a/src/wwwroot/js/genpage/gentab/models.js
+++ b/src/wwwroot/js/genpage/gentab/models.js
@@ -171,9 +171,9 @@ function editModel(model, browser) {
     }
     getRequiredElementById('edit_model_is_negative').checked = model.is_negative_embedding || false;
     getRequiredElementById('edit_model_is_negative_div').style.display = model.architecture && model.architecture.endsWith('/textual-inversion') ? 'block' : 'none';
-    getRequiredElementById('edit_model_lora_default_weight').value = '';
+    getRequiredElementById('edit_model_lora_default_weight').value = model.lora_default_weight || '';
     getRequiredElementById('edit_model_lora_default_weight_div').style.display = model.architecture && model.architecture.endsWith('/lora') ? 'block' : 'none';
-    getRequiredElementById('edit_model_lora_default_confinement').value = '';
+    getRequiredElementById('edit_model_lora_default_confinement').value = model.lora_default_confinement || '';
     getRequiredElementById('edit_model_lora_default_confinement_div').style.display = model.architecture && model.architecture.endsWith('/lora') ? 'block' : 'none';
     $('#edit_model_modal').modal('show');
 }


### PR DESCRIPTION
Thanks for the recent feature on Default LoRA Weight!

A small follow-up fix, when editing a LoRA this value was not loaded from model (saving works)