### PR TITLE
Improved themability

### DIFF
--- a/src/wwwroot/css/genpage.css
+++ b/src/wwwroot/css/genpage.css
@@ -468,8 +468,8 @@ body {
     opacity: 1.0;
     background-color: var(--emphasis) !important;
     cursor: pointer;
-    border: 1px solid var(--model-block-menu-button-border-color-hover);
-    color: var(--model-block-menu-button-color-hover);
+    border: 1px solid var(--button-border);
+    color: var(--text-strong);
 }
 .model-selected {
     border: 1px solid var(--box-selected-border-stronger);

--- a/src/wwwroot/css/genpage.css
+++ b/src/wwwroot/css/genpage.css
@@ -416,7 +416,7 @@ body {
     overflow: auto;
 }
 .model-block img:hover {
-    border: 2px solid white;
+    border: 2px solid var(--model-img-border-color-hover);
 }
 .model-block-small {
     height: 8rem;
@@ -468,7 +468,8 @@ body {
     opacity: 1.0;
     background-color: var(--emphasis) !important;
     cursor: pointer;
-    border: 1px solid black;
+    border: 1px solid var(--model-block-menu-button-border-color-hover);
+    color: var(--model-block-menu-button-color-hover);
 }
 .model-selected {
     border: 1px solid var(--box-selected-border-stronger);
@@ -590,10 +591,10 @@ body {
     margin-left: 5%;
 }
 .modal_error_bottom {
-    color: #ff0000;
+    color: var(--red);
 }
 .modal_success_bottom {
-    color: #00ff00;
+    color: var(--green);
 }
 #add_preset_modal {
     max-height: calc(95vh - var(--bs-modal-margin));
@@ -634,7 +635,7 @@ body {
     display: inline-block;
     color: var(--text);
     font-weight: bold;
-    border: 1px solid red;
+    border: 1px solid var(--red);
     border-radius: 0.5rem;
     margin-left: 0.2rem;
     padding-left: 0.2rem;
@@ -642,7 +643,7 @@ body {
     cursor: pointer;
 }
 .preset-remove-button:hover {
-    background-color: color-mix(in srgb, red 70%, black);
+    background-color: color-mix(in srgb, var(--red) 70%, black);
 }
 .new_preset_image {
     align-items: center;
@@ -720,8 +721,8 @@ body {
     padding-left: 2rem;
 }
 .setting-looks-wrong {
-    border: 1px  solid red !important;
-    box-shadow: 0px 0px 1px 1px red !important;
+    border: 1px  solid var(--red) !important;
+    box-shadow: 0px 0px 1px 1px var(--red) !important;
 }
 .group-label {
     position: relative;
@@ -1053,12 +1054,12 @@ body {
 .alt-prompt-image-container:hover .alt-prompt-image-container-remove-button {
     opacity: 1.0;
     background-color: color-mix(in srgb, transparent 50%, var(--background));
-    border: 1px solid red;
+    border: 1px solid var(--red);
 }
 
 .alt-prompt-image-container-remove-button:hover {
     opacity: 1.0;
-    background-color: color-mix(in srgb, red 70%, black) !important;
+    background-color: color-mix(in srgb, var(--red) 70%, black) !important;
     border: 1px solid black;
     cursor: pointer;
 }
@@ -1110,10 +1111,10 @@ body {
     padding-left: 0.6rem;
     padding-right: 0.6rem;
     margin: 1px;
-    background-color: color-mix(in srgb, var(--background) 70%, #ffff00);
+    background-color: color-mix(in srgb, var(--background) 70%, var(--yellow));
 }
 .clip-tokenization-word-tweak {
-    background-color: color-mix(in srgb, var(--background) 70%, #00ff00);
+    background-color: color-mix(in srgb, var(--background) 70%, var(--green));
 }
 .clip-tokenization-wordbreak {
     font-size: 80%;
@@ -1156,7 +1157,7 @@ body {
     left: 0;
     width: 0;
     height: 2px;
-    background-color: #00ff00;
+    background-color: var(--green);
 }
 .controlnet-preview-result img {
     max-width: 200px;

--- a/src/wwwroot/css/site.css
+++ b/src/wwwroot/css/site.css
@@ -13,7 +13,38 @@
     --toggle-thumb-hover: var(--button-background-hover);
     --toggle-thumb-active-hover: color-mix(in srgb, var(--emphasis) 25%, white);
     --font-monospace: 'Courier New', Courier, monospace;
+    --yellow: #ffff00;
     --star: #ffff00;
+    --status-bar-text-color: #000000;
+    --status-bar-warn-color-start-end: #dddd55;
+    --status-bar-warn-color-middle: #888800;
+    --status-bar-error-color-start-end: #bb2020;
+    --status-bar-error-color-middle: #880000;
+    --status-bar-soft-color: #888800;
+    --backend-errored-border-color: #ff0000;
+    --backend-disabled-border-color: #ffaa00;
+    --backend-running-border-color: #00aa33;
+    --backend-idle-border-color: #688772;
+    --backend-loading-border-color: #335500;
+    --backend-waiting-border-color: #335500;
+    --backend-edit-btn-text-color-hover: #000000;
+    --backend-edit-btn-border-color-hover: #000000;
+    --backend-edit-btn-text-color-disabled: #505050;
+    --backend-edit-btn-border-color-disabled: #505050;
+    --backend-delete-btn-text-color-hover: #000000;
+    --backend-delete-btn-border-color-hover: #000000;
+    --backend-save-btn-text-color-hover: #000000;
+    --backend-save-btn-border-color-hover: #000000;
+    --basic-button-bg-color-disabled: rgba(100, 0, 0, 0.5);
+    --notice-pop-green-bg-color: #005500;
+    --slider-toggle-background: #ccc;
+    --slider-toggle-thumb-color: #4b4b4b;
+    --link-color: rgba(var(--bs-link-color-rgb),var(--bs-link-opacity,1));
+    --code-color: var(--bs-code-color);
+    --model-img-border-color-hover: white;
+    --model-block-menu-button-border-color-hover: black;
+    --model-block-menu-button-color-hover: white;
+    --qbutton-foreground-color-hover: #000000;
 }
 .modal-content {
     background-color: var(--background) !important;
@@ -33,14 +64,14 @@ body {
     --bs-body-font-family: var(--bs-font-sans-serif);
 }
 @keyframes status_glow-warn {
-    0% {background-color: #dddd55;}
-    50% {background-color: #888800;}
-    100% {background-color: #dddd55;}
+    0% {background-color: var(--status-bar-warn-color-start-end);}
+    50% {background-color: var(--status-bar-warn-color-middle);}
+    100% {background-color: var(--status-bar-warn-color-start-end);}
 }
 @keyframes status_glow-error {
-    0% {background-color: #bb2020;}
-    50% {background-color: #880000;}
-    100% {background-color: #bb2020;}
+    0% {background-color: var(--status-bar-error-color-start-end);}
+    50% {background-color: var(--status-bar-error-color-middle);}
+    100% {background-color: var(--status-bar-error-color-start-end);}
 }
 .password {
     text-security: disc;
@@ -60,7 +91,7 @@ body {
 }
 .top-status-bar {
     position: absolute;
-    color: #000000;
+    color: var(--status-bar-text-color);
     top: 0px;
     width: 100vw;
     z-index: 100;
@@ -76,7 +107,7 @@ body {
     animation-name: status_glow-error;
 }
 .status-bar-soft {
-    background-color: #888800;
+    background-color: var(--status-bar-soft-color);
 }
 .auto-input {
     display: block;
@@ -132,22 +163,25 @@ body {
     padding: 1.5px;
 }
 .backend-errored {
-    border: 1px solid #ff0000;
+    border: 1px solid var(--backend-errored-border-color);
 }
 .backend-disabled {
-    border: 1px solid #ffaa00;
+    border: 1px solid var(--backend-disabled-border-color);
 }
 .backend-running {
-    border: 1px solid #00aa33;
+    border: 1px solid var(--backend-running-border-color);
 }
 .backend-idle {
-    border: 1px solid #688772;
+    border: 1px solid var(--backend-idle-border-color);
 }
 .backend-loading {
-    border: 1px solid #335500;
+    border: 1px solid var(--backend-loading-border-color);
 }
 .backend-waiting {
-    border: 1px solid #335500;
+    border: 1px solid var(--backend-waiting-border-color);
+}
+.card {
+    color: var(--text);
 }
 .card-header {
     background-color: var(--background-gray);
@@ -179,13 +213,13 @@ body {
     border: 1px solid var(--green);
 }
 .backend-edit-button:hover {
-    color: #000000 !important;
-    border: 1px solid #000000 !important;
+    color: var(--backend-edit-btn-text-color-hover) !important;
+    border: 1px solid var(--backend-edit-btn-border-color-hover) !important;
     background-color: var(--green) !important;
 }
 .backend-edit-button:disabled {
-    color: #505050 !important;
-    border: 1px solid #505050 !important;
+    color: var(--backend-edit-btn-text-color-disabled) !important;
+    border: 1px solid var(--backend-edit-btn-border-color-disabled) !important;
     background-color: transparent !important;
 }
 .backend-delete-button {
@@ -193,8 +227,8 @@ body {
     border: 1px solid var(--red);
 }
 .backend-delete-button:hover {
-    color: #000000 !important;
-    border: 1px solid #000000 !important;
+    color: var(--backend-delete-btn-text-color-hover) !important;
+    border: 1px solid var(--backend-delete-btn-border-color-hover) !important;
     background-color: var(--red) !important;
 }
 .backend-save-button {
@@ -203,8 +237,8 @@ body {
     border: 1px solid var(--green);
 }
 .backend-save-button:hover {
-    color: #000000 !important;
-    border: 1px solid #000000 !important;
+    color: var(--backend-save-btn-text-color-hover) !important;
+    border: 1px solid var(--backend-save-btn-border-color-hover) !important;
     background-color: var(--green) !important;
 }
 .backend-toggle-switch {
@@ -355,7 +389,7 @@ textarea, input, select {
 }
 @keyframes toast-flash {
     0% {background-color: transparent;}
-    50% {background-color: #FF0000;}
+    50% {background-color: var(--red);}
     100% {background-color: transparent;}
 }
 .center-toast {
@@ -379,7 +413,7 @@ textarea, input, select {
 }
 .auto-input-qbutton:hover {
     background-color: var(--qbutton);
-    color: #000000 !important;
+    color: var(--qbutton-foreground-color-hover) !important;
 }
 .sui-popover {
     background-color: var(--popup-back);
@@ -530,11 +564,20 @@ textarea, input, select {
     background-color: color-mix(in srgb, var(--button-background-hover) 50%, var(--emphasis));
 }
 .basic-button:disabled {
-    background-color: color-mix(in srgb, var(--button-background) 40%, rgba(100, 0, 0, 0.5));
+    background-color: color-mix(in srgb, var(--button-background) 40%, var(--basic-button-bg-color-disabled));
     color: color-mix(in srgb, var(--button-text) 60%, transparent);
 }
 .simpler-button-disable:disabled {
     background-color: color-mix(in srgb, var(--button-background) 40%, transparent);
+}
+.btn-secondary {
+    background-color: var(--button-background);
+    color: var(--button-text);
+    border: 1px solid var(--button-border);
+}
+.btn-secondary:hover {
+    background-color: var(--button-background-hover);
+    color: var(--button-foreground-hover);
 }
 .text_button {
     background-color: color-mix(in srgb, var(--button-background) 50%, transparent);
@@ -553,6 +596,14 @@ textarea, input, select {
     margin-bottom: 0.1rem;
     border-radius: 0.5rem;
     background-color: transparent;
+}
+.dropdown-menu {
+    --bs-dropdown-bg: var(--popup-back);
+    --bs-dropdown-border-color: gray;
+    color: var(--popup-front);
+}
+.dropdown-divider {
+    border-color: gray;
 }
 .info-popover-button {
     cursor: pointer;
@@ -761,8 +812,8 @@ textarea, input, select {
     width: fit-content;
 }
 .notice-pop-green {
-    background-color: #005500;
-    color: #ffffff;
+    background-color: var(--notice-pop-green-bg-color);
+    color: var(--text);
 }
 .drag_image_target_highlight {
     box-shadow: inset 0 0 8px 2px var(--emphasis);
@@ -945,7 +996,7 @@ input[type="range"]::-moz-range-track {
     box-shadow: inset 0px 0px 3px rgba(0, 0, 0, 0.35);
     border-radius: 16px;
     pointer-events: none;
-    background: #ccc;
+    background: var(--slider-toggle-background);
 }
 .auto-slider-toggle-content::after {
     content: "";
@@ -954,7 +1005,7 @@ input[type="range"]::-moz-range-track {
     left: -1px;
     width: var(--toggle-thumb-size);
     height: var(--toggle-thumb-size);
-    background: #4b4b4b;
+    background: var(--slider-toggle-thumb-color);
     border-radius: 20px;
     transition: left 0.2s, background-color 0.2s;
 }

--- a/src/wwwroot/css/site.css
+++ b/src/wwwroot/css/site.css
@@ -13,35 +13,35 @@
     --toggle-thumb-hover: var(--button-background-hover);
     --toggle-thumb-active-hover: color-mix(in srgb, var(--emphasis) 25%, white);
     --font-monospace: 'Courier New', Courier, monospace;
+    --red: #ff0000;
+    --green: #00ff00;
     --yellow: #ffff00;
+    --white: #ffffff;
+    --black: #000000;
     --star: #ffff00;
+    --gray: #808080;
+    --darkgray: #505050;
+    --transparentdarkred: rgba(100, 0, 0, 0.5);
     --status-bar-text-color: #000000;
     --status-bar-warn-color-start-end: #dddd55;
     --status-bar-warn-color-middle: #888800;
     --status-bar-error-color-start-end: #bb2020;
     --status-bar-error-color-middle: #880000;
     --status-bar-soft-color: #888800;
-    --backend-errored-border-color: #ff0000;
-    --backend-disabled-border-color: #ffaa00;
-    --backend-running-border-color: #00aa33;
-    --backend-idle-border-color: #688772;
-    --backend-loading-border-color: #335500;
-    --backend-waiting-border-color: #335500;
-    --backend-button-foreground-hover: #000000;
-    --backend-button-foreground-disabled: #505050;
-    --basic-button-bg-color-disabled: rgba(100, 0, 0, 0.5);
-    --dropdown-border-color: gray;
-    --notice-pop-green-bg-color: #005500;
-    --toast-header-bg: #303030;
-    --toast-body-bg: #444;
-    --slider-toggle-background: #ccc;
-    --slider-toggle-thumb-color: #4b4b4b;
-    --link-color: rgba(var(--bs-link-color-rgb),var(--bs-link-opacity,1));
-    --code-color: var(--bs-code-color);
-    --model-img-border-color-hover: white;
+    --backend-errored: #ff0000;
+    --backend-disabled: #ffaa00;
+    --backend-running: #00aa33;
+    --backend-idle: #688772;
+    --backend-loading: #335500;
+    --backend-waiting: #335500;
+    --notice-pop: #005500;
+    --toast-header: #303030;
+    --toast-body: #444;
+    --toggle-background: #ccc;
+    --toggle-thumb-color: #4b4b4b;
+    --model-img-border-color-hover: #ffffff;
     --model-block-menu-button-border-color-hover: black;
     --model-block-menu-button-color-hover: white;
-    --qbutton-foreground-color-hover: #000000;
 }
 .modal-content {
     background-color: var(--background) !important;
@@ -160,22 +160,22 @@ body {
     padding: 1.5px;
 }
 .backend-errored {
-    border: 1px solid var(--backend-errored-border-color);
+    border: 1px solid var(--backend-errored);
 }
 .backend-disabled {
-    border: 1px solid var(--backend-disabled-border-color);
+    border: 1px solid var(--backend-disabled);
 }
 .backend-running {
-    border: 1px solid var(--backend-running-border-color);
+    border: 1px solid var(--backend-running);
 }
 .backend-idle {
-    border: 1px solid var(--backend-idle-border-color);
+    border: 1px solid var(--backend-idle);
 }
 .backend-loading {
-    border: 1px solid var(--backend-loading-border-color);
+    border: 1px solid var(--backend-loading);
 }
 .backend-waiting {
-    border: 1px solid var(--backend-waiting-border-color);
+    border: 1px solid var(--backend-waiting);
 }
 .card {
     color: var(--text);
@@ -210,13 +210,13 @@ body {
     border: 1px solid var(--green);
 }
 .backend-edit-button:hover {
-    color: var(--backend-button-foreground-hover) !important;
-    border: 1px solid var(--backend-button-foreground-hover) !important;
+    color: var(--black) !important;
+    border: 1px solid var(--black) !important;
     background-color: var(--green) !important;
 }
 .backend-edit-button:disabled {
-    color: var(--backend-button-foreground-disabled) !important;
-    border: 1px solid var(--backend-button-foreground-disabled) !important;
+    color: var(--darkgray) !important;
+    border: 1px solid var(--darkgray) !important;
     background-color: transparent !important;
 }
 .backend-delete-button {
@@ -224,8 +224,8 @@ body {
     border: 1px solid var(--red);
 }
 .backend-delete-button:hover {
-    color: var(--backend-button-foreground-hover) !important;
-    border: 1px solid var(--backend-button-foreground-hover) !important;
+    color: var(--black) !important;
+    border: 1px solid var(--black) !important;
     background-color: var(--red) !important;
 }
 .backend-save-button {
@@ -234,8 +234,8 @@ body {
     border: 1px solid var(--green);
 }
 .backend-save-button:hover {
-    color: var(--backend-button-foreground-hover) !important;
-    border: 1px solid var(--backend-button-foreground-hover) !important;
+    color: var(--black) !important;
+    border: 1px solid var(--black) !important;
     background-color: var(--green) !important;
 }
 .backend-toggle-switch {
@@ -407,11 +407,11 @@ textarea, input, select {
     animation-duration: 2s;
 }
 .toast {
-    background-color: var(--toast-body-bg);
+    background-color: var(--toast-body);
     color: var(--text);
 }
 .toast-header {
-    background-color: var(--toast-header-bg);
+    background-color: var(--toast-header);
     color: var(--text);
 }
 .auto-input-qbutton {
@@ -425,7 +425,7 @@ textarea, input, select {
 }
 .auto-input-qbutton:hover {
     background-color: var(--qbutton);
-    color: var(--qbutton-foreground-color-hover) !important;
+    color: var(--text-strong) !important;
 }
 .sui-popover {
     background-color: var(--popup-back);
@@ -576,20 +576,11 @@ textarea, input, select {
     background-color: color-mix(in srgb, var(--button-background-hover) 50%, var(--emphasis));
 }
 .basic-button:disabled {
-    background-color: color-mix(in srgb, var(--button-background) 40%, var(--basic-button-bg-color-disabled));
+    background-color: color-mix(in srgb, var(--button-background) 40%, var(--transparentdarkred));
     color: color-mix(in srgb, var(--button-text) 60%, transparent);
 }
 .simpler-button-disable:disabled {
     background-color: color-mix(in srgb, var(--button-background) 40%, transparent);
-}
-.rst-welcome-msg-btn {
-    background-color: var(--button-background);
-    color: var(--button-text);
-    border: 1px solid var(--button-border);
-}
-.rst-welcome-msg-btn:hover {
-    background-color: var(--button-background-hover);
-    color: var(--button-foreground-hover);
 }
 .text_button {
     background-color: color-mix(in srgb, var(--button-background) 50%, transparent);
@@ -610,12 +601,12 @@ textarea, input, select {
     background-color: transparent;
 }
 .dropdown-menu {
-    --bs-dropdown-bg: var(--popup-back);
-    --bs-dropdown-border-color: var(--dropdown-border-color);
+    background-color: var(--popup-back);
+    border-color: var(--light-border);
     color: var(--popup-front);
 }
 .dropdown-divider {
-    border-color: var(--dropdown-border-color);
+    border-color: var(--light-border);
 }
 .info-popover-button {
     cursor: pointer;
@@ -824,7 +815,7 @@ textarea, input, select {
     width: fit-content;
 }
 .notice-pop-green {
-    background-color: var(--notice-pop-green-bg-color);
+    background-color: var(--notice-pop);
     color: var(--text);
 }
 .drag_image_target_highlight {
@@ -1008,7 +999,7 @@ input[type="range"]::-moz-range-track {
     box-shadow: inset 0px 0px 3px rgba(0, 0, 0, 0.35);
     border-radius: 16px;
     pointer-events: none;
-    background: var(--slider-toggle-background);
+    background: var(--toggle-background);
 }
 .auto-slider-toggle-content::after {
     content: "";
@@ -1017,7 +1008,7 @@ input[type="range"]::-moz-range-track {
     left: -1px;
     width: var(--toggle-thumb-size);
     height: var(--toggle-thumb-size);
-    background: var(--slider-toggle-thumb-color);
+    background: var(--toggle-thumb-color);
     border-radius: 20px;
     transition: left 0.2s, background-color 0.2s;
 }

--- a/src/wwwroot/css/site.css
+++ b/src/wwwroot/css/site.css
@@ -27,15 +27,10 @@
     --backend-idle-border-color: #688772;
     --backend-loading-border-color: #335500;
     --backend-waiting-border-color: #335500;
-    --backend-edit-btn-text-color-hover: #000000;
-    --backend-edit-btn-border-color-hover: #000000;
-    --backend-edit-btn-text-color-disabled: #505050;
-    --backend-edit-btn-border-color-disabled: #505050;
-    --backend-delete-btn-text-color-hover: #000000;
-    --backend-delete-btn-border-color-hover: #000000;
-    --backend-save-btn-text-color-hover: #000000;
-    --backend-save-btn-border-color-hover: #000000;
+    --backend-button-foreground-hover: #000000;
+    --backend-button-foreground-disabled: #505050;
     --basic-button-bg-color-disabled: rgba(100, 0, 0, 0.5);
+    --dropdown-border-color: gray;
     --notice-pop-green-bg-color: #005500;
     --slider-toggle-background: #ccc;
     --slider-toggle-thumb-color: #4b4b4b;
@@ -213,13 +208,13 @@ body {
     border: 1px solid var(--green);
 }
 .backend-edit-button:hover {
-    color: var(--backend-edit-btn-text-color-hover) !important;
-    border: 1px solid var(--backend-edit-btn-border-color-hover) !important;
+    color: var(--backend-button-foreground-hover) !important;
+    border: 1px solid var(--backend-button-foreground-hover) !important;
     background-color: var(--green) !important;
 }
 .backend-edit-button:disabled {
-    color: var(--backend-edit-btn-text-color-disabled) !important;
-    border: 1px solid var(--backend-edit-btn-border-color-disabled) !important;
+    color: var(--backend-button-foreground-disabled) !important;
+    border: 1px solid var(--backend-button-foreground-disabled) !important;
     background-color: transparent !important;
 }
 .backend-delete-button {
@@ -227,8 +222,8 @@ body {
     border: 1px solid var(--red);
 }
 .backend-delete-button:hover {
-    color: var(--backend-delete-btn-text-color-hover) !important;
-    border: 1px solid var(--backend-delete-btn-border-color-hover) !important;
+    color: var(--backend-button-foreground-hover) !important;
+    border: 1px solid var(--backend-button-foreground-hover) !important;
     background-color: var(--red) !important;
 }
 .backend-save-button {
@@ -237,8 +232,8 @@ body {
     border: 1px solid var(--green);
 }
 .backend-save-button:hover {
-    color: var(--backend-save-btn-text-color-hover) !important;
-    border: 1px solid var(--backend-save-btn-border-color-hover) !important;
+    color: var(--backend-button-foreground-hover) !important;
+    border: 1px solid var(--backend-button-foreground-hover) !important;
     background-color: var(--green) !important;
 }
 .backend-toggle-switch {
@@ -401,6 +396,14 @@ textarea, input, select {
     transform: translate(-50%, 0);
     animation-name: toast-flash;
     animation-duration: 2s;
+}
+.toast {
+    background-color: var(--toast-body-bg, var(--bs-toast-bg));
+    color: var(--text);
+}
+.toast-header {
+    background-color: var(--toast-header-bg, var(--bs-toast-header-bg));
+    color: var(--text);
 }
 .auto-input-qbutton {
     margin-left: 0.25rem;
@@ -570,12 +573,12 @@ textarea, input, select {
 .simpler-button-disable:disabled {
     background-color: color-mix(in srgb, var(--button-background) 40%, transparent);
 }
-.btn-secondary {
+.rst-welcome-msg-btn {
     background-color: var(--button-background);
     color: var(--button-text);
     border: 1px solid var(--button-border);
 }
-.btn-secondary:hover {
+.rst-welcome-msg-btn:hover {
     background-color: var(--button-background-hover);
     color: var(--button-foreground-hover);
 }
@@ -599,11 +602,11 @@ textarea, input, select {
 }
 .dropdown-menu {
     --bs-dropdown-bg: var(--popup-back);
-    --bs-dropdown-border-color: gray;
+    --bs-dropdown-border-color: var(--dropdown-border-color);
     color: var(--popup-front);
 }
 .dropdown-divider {
-    border-color: gray;
+    border-color: var(--dropdown-border-color);
 }
 .info-popover-button {
     cursor: pointer;

--- a/src/wwwroot/css/site.css
+++ b/src/wwwroot/css/site.css
@@ -32,6 +32,8 @@
     --basic-button-bg-color-disabled: rgba(100, 0, 0, 0.5);
     --dropdown-border-color: gray;
     --notice-pop-green-bg-color: #005500;
+    --toast-header-bg: #303030;
+    --toast-body-bg: #444;
     --slider-toggle-background: #ccc;
     --slider-toggle-thumb-color: #4b4b4b;
     --link-color: rgba(var(--bs-link-color-rgb),var(--bs-link-opacity,1));
@@ -333,6 +335,13 @@ input[type="range"]::-webkit-slider-thumb, input[type="range"]::-moz-range-thumb
     box-shadow: -407px 0 0 400px var(--emphasis);
     margin-top: -4px;
 }
+input[type="checkbox"] {
+    accent-color: var(--emphasis);
+}
+input[type="text"]:focus, textarea:focus {
+    outline: solid 1px var(--emphasis);
+    border-color: var(--emphasis);
+}
 .auto-slider-range-wrapper {
     display: contents;
 }
@@ -398,11 +407,11 @@ textarea, input, select {
     animation-duration: 2s;
 }
 .toast {
-    background-color: var(--toast-body-bg, var(--bs-toast-bg));
+    background-color: var(--toast-body-bg);
     color: var(--text);
 }
 .toast-header {
-    background-color: var(--toast-header-bg, var(--bs-toast-header-bg));
+    background-color: var(--toast-header-bg);
     color: var(--text);
 }
 .auto-input-qbutton {

--- a/src/wwwroot/css/themes/beweish.css
+++ b/src/wwwroot/css/themes/beweish.css
@@ -10,6 +10,7 @@
     
     /* Text colors */
     --text: #ffffff;
+    --text-strong: #ffffff;
     --text-soft: #e0e0e0;
     --popup-front: #ffffff;
     

--- a/src/wwwroot/css/themes/cyber_swarm.css
+++ b/src/wwwroot/css/themes/cyber_swarm.css
@@ -49,6 +49,7 @@
     --batch-0: rgba(200, 200, 200, 0.3);
     --batch-1: rgba(200, 200, 200, 0.3);
     --text: #eeeeee;
+    --text-strong: #ffffff;
     --text-soft: #aaaaaa;
     --box-selected-border: rgba(120, 85, 225, 0.8);
     --box-selected-background: rgba(120, 85, 225, 0.2);

--- a/src/wwwroot/css/themes/dark_dreams.css
+++ b/src/wwwroot/css/themes/dark_dreams.css
@@ -27,6 +27,7 @@
     --batch-0: rgba(200, 200, 200, 0.3);
     --batch-1: rgba(200, 200, 200, 0.3);
     --text: #eeeeee;
+    --text-strong: #ffffff;
     --text-soft: #aaaaaa;
     --box-selected-border: rgba(120, 85, 225, 0.8);
     --box-selected-background: rgba(120, 85, 225, 0.2);

--- a/src/wwwroot/css/themes/eyesear_white.css
+++ b/src/wwwroot/css/themes/eyesear_white.css
@@ -32,4 +32,6 @@
     --box-selected-background: rgba(255, 162, 85, 0.2);
     --box-selected-border-stronger: rgba(255, 162, 85, 1.0);
     --box-selected-background-stronger: rgba(255, 162, 85, 0.3);
+    --toast-header-bg: #ffffffd9;
+    --toast-body-bg: #ffffffd9;
 }

--- a/src/wwwroot/css/themes/eyesear_white.css
+++ b/src/wwwroot/css/themes/eyesear_white.css
@@ -27,6 +27,7 @@
     --batch-0: rgba(200, 200, 200, 0.3);
     --batch-1: rgba(200, 200, 200, 0.3);
     --text: #101010;
+    --text-strong: #000000;
     --text-soft: #303030;
     --box-selected-border: rgba(225, 162, 85, 0.8);
     --box-selected-background: rgba(255, 162, 85, 0.2);

--- a/src/wwwroot/css/themes/gravity_blue.css
+++ b/src/wwwroot/css/themes/gravity_blue.css
@@ -27,6 +27,7 @@
     --batch-0: rgba(200, 200, 200, 0.3);
     --batch-1: rgba(200, 200, 200, 0.3);
     --text: #eeeeee;
+    --text-strong: #ffffff;
     --text-soft: #aaaaaa;
     --box-selected-border: rgba(225, 162, 85, 0.8);
     --box-selected-background: rgba(255, 162, 85, 0.2);

--- a/src/wwwroot/css/themes/modern_dark.css
+++ b/src/wwwroot/css/themes/modern_dark.css
@@ -9,6 +9,7 @@
     --text-soft: #aaa;
     --background: #161616;
     --text: #E4E4E4;
+    --text-strong: #ffffff;
     --emphasis: #7855e1;
     --emphasis-soft: #665694;
     --button-text: #fff;

--- a/src/wwwroot/css/themes/modern_light.css
+++ b/src/wwwroot/css/themes/modern_light.css
@@ -20,4 +20,6 @@
     --range-track-color: #B1B1B1;
     --range-thumb-color: #a1a1a1;
     --qbutton: #8b6445;
+    --toast-header-bg: #ffffffd9;
+    --toast-body-bg: #ffffffd9;
 }

--- a/src/wwwroot/css/themes/modern_light.css
+++ b/src/wwwroot/css/themes/modern_light.css
@@ -6,9 +6,10 @@
     --light-border: #728787;
     --popup-front: hsl(0, 0%, 6%);
     --button-foreground-disabled: #fff;
-    --text-soft: #525252;
     --background: #aaa;
     --text: #101010;
+    --text-strong: #000000;
+    --text-soft: #525252;
     --emphasis: #c7966b;
     --emphasis-soft: #c7966b;
     --button-text: #101010;

--- a/src/wwwroot/css/themes/punked.css
+++ b/src/wwwroot/css/themes/punked.css
@@ -29,6 +29,7 @@
     --batch-0: rgba(200, 200, 200, 0.3);
     --batch-1: rgba(200, 200, 200, 0.3);
     --text: #eeeeee;
+    --text-strong: #ffffff;
     --text-soft: #aaaaaa;
     --box-selected-border: rgba(120, 85, 225, 0.8);
     --box-selected-background: rgba(120, 85, 225, 0.2);

--- a/src/wwwroot/css/themes/solarized.css
+++ b/src/wwwroot/css/themes/solarized.css
@@ -20,6 +20,8 @@
     --range-track-color: #B1B1B1;
     --range-thumb-color: #a1a1a1;
     --qbutton: #8b6445;
+    --toast-header-bg: #ffffffd9;
+    --toast-body-bg: #ffffffd9;
 }
 body {
     scrollbar-color: #a1a1a1 #dbd4c3;

--- a/src/wwwroot/css/themes/solarized.css
+++ b/src/wwwroot/css/themes/solarized.css
@@ -6,9 +6,10 @@
     --light-border: #A4A4A4;
     --popup-front: hsl(0, 0%, 6%);
     --button-foreground-disabled: #fff;
-    --text-soft: #525252;
     --background: #d3cdc0;
     --text: #101010;
+    --text-strong: #000000;
+    --text-soft: #525252;
     --emphasis: #c76bbb;
     --emphasis-soft: #c76bbb;
     --button-text: #101010;

--- a/src/wwwroot/css/themes/swarmpunk.css
+++ b/src/wwwroot/css/themes/swarmpunk.css
@@ -10,6 +10,7 @@
     
     /* Text colors */
     --text: #00ff9d;
+    --text-strong: #10ffa0;
     --text-soft: #00ccff;
     --popup-front: #00ff9d;
     

--- a/src/wwwroot/js/genpage/gentab/welcomemessages.js
+++ b/src/wwwroot/js/genpage/gentab/welcomemessages.js
@@ -75,6 +75,6 @@ function automaticWelcomeMessage(override = null) {
     if (override < 0) {
         override += messages.length;
     }
-    div.innerHTML = `${prefix}\n<div class="welcome-message-wrapper">${messages[override]}</div>\n\n<button class="btn btn-secondary" onclick="resetWelcomeMessage(${override - 1})">&lt;</button> <button class="btn btn-secondary" onclick="resetWelcomeMessage(${override + 1})">&gt;</button>`;
+    div.innerHTML = `${prefix}\n<div class="welcome-message-wrapper">${messages[override]}</div>\n\n<button class="btn btn-secondary rst-welcome-msg-btn" onclick="resetWelcomeMessage(${override - 1})">&lt;</button> <button class="btn btn-secondary rst-welcome-msg-btn" onclick="resetWelcomeMessage(${override + 1})">&gt;</button>`;
     return;
 }

--- a/src/wwwroot/js/genpage/gentab/welcomemessages.js
+++ b/src/wwwroot/js/genpage/gentab/welcomemessages.js
@@ -75,6 +75,6 @@ function automaticWelcomeMessage(override = null) {
     if (override < 0) {
         override += messages.length;
     }
-    div.innerHTML = `${prefix}\n<div class="welcome-message-wrapper">${messages[override]}</div>\n\n<button class="btn btn-secondary rst-welcome-msg-btn" onclick="resetWelcomeMessage(${override - 1})">&lt;</button> <button class="btn btn-secondary rst-welcome-msg-btn" onclick="resetWelcomeMessage(${override + 1})">&gt;</button>`;
+    div.innerHTML = `${prefix}\n<div class="welcome-message-wrapper">${messages[override]}</div>\n\n<button class="basic-button" onclick="resetWelcomeMessage(${override - 1})">&lt;</button> <button class="basic-button" onclick="resetWelcomeMessage(${override + 1})">&gt;</button>`;
     return;
 }


### PR DESCRIPTION
- Moved nearly all hardcoded colors to their own vars or appropriate existing vars
- Made btn-secondary themeable
- Made toasts themeable

A few of the changes done cause a slight (almost unnoticeable) change in the default color of a small amount of things on Modern Dark, and a slightly more noticeable change on Modern Light. But makes all themes more consistent and more themed.

Notable changes observed in existing themes can be seen in the following two examples. IDK if this is considered breakage, as it (in my opinion) improves them:
_Example of language menu dropdown with the Punked theme (Legacy):_
<img width="1180" height="949" alt="image" src="https://github.com/user-attachments/assets/740c5141-ffd0-4631-a4cb-4d3a4959071e" />
_Example of btn-secondary with the Swarm Punk theme:_
<img width="1554" height="697" alt="image" src="https://github.com/user-attachments/assets/7f214fc7-93b7-4aa0-97f3-730658bc4472" />

Note that many variable names are long and descriptive (the longest one being `--model-block-menu-button-border-color-hover`).

*Edit: Removed irrelevant section & added one item to the list*