### PR TITLE
Fix non-rounded corners for toast flash animation

### DIFF
--- a/src/wwwroot/css/site.css
+++ b/src/wwwroot/css/site.css
@@ -367,6 +367,7 @@ textarea, input, select {
     transform: translate(-50%, 0);
     animation-name: toast-flash;
     animation-duration: 2s;
+    border-radius: 6px;
 }
 .auto-input-qbutton {
     margin-left: 0.25rem;


### PR DESCRIPTION
A simple fix for a small issue.

Before:
<img width="634" height="178" alt="image" src="https://github.com/user-attachments/assets/492b6786-5c47-4580-a61b-c89b52c1e226" />  
After:
<img width="634" height="178" alt="image" src="https://github.com/user-attachments/assets/84a2f598-3ffc-48b3-88af-bcc18ea8b731" />

I compared `border-radius: calc(0.375em + 1px);` and `border-radius: calc(0.375rem + 1px);` with `border-radius: 6px;`, and I found that the one with `6px` has a more consistent border thickness. Though, this difference is minuscule, and was only visible on my 4K monitor, not on my 1440p or 1080p monitors.

_Why specifically test `0.375(r)em`? Because that is what `.toast` has as its border radius._
<img width="592" height="150" alt="image" src="https://github.com/user-attachments/assets/f124c77a-4ab6-4d19-b015-e6bb19fce980" />