### PR TITLE
Add GetGlobalStatus to API for getting system-wide status about running and waiting generations

### DIFF
--- a/docs/APIRoutes/AdminAPI.md
+++ b/docs/APIRoutes/AdminAPI.md
@@ -16,6 +16,7 @@ Administrative APIs related to server management.
 - HTTP Route [ChangeServerSettings](#http-route-apichangeserversettings)
 - HTTP Route [DebugGenDocs](#http-route-apidebuggendocs)
 - HTTP Route [DebugLanguageAdd](#http-route-apidebuglanguageadd)
+- HTTP Route [GetGlobalStatus](#http-route-apigetglobalstatus)
 - HTTP Route [GetServerResourceInfo](#http-route-apigetserverresourceinfo)
 - HTTP Route [InstallExtension](#http-route-apiinstallextension)
 - HTTP Route [ListConnectedUsers](#http-route-apilistconnectedusers)
@@ -267,6 +268,38 @@ Changes server settings.
 
 ```js
 "success": true
+```
+
+## HTTP Route /API/GetGlobalStatus
+
+#### Description
+
+Get global server-wide generation status across all sessions.
+
+#### Permission Flag
+
+`read_server_info_panels` - `Read Server Info Panels` in group `Admin`
+
+#### Parameters
+
+**None.**
+
+#### Return Format
+
+```js
+    "status": {
+        "waiting_gens": 0,
+        "loading_models": 0,
+        "waiting_backends": 0,
+        "live_gens": 0
+    },
+    "backend_status": {
+        "status": "running", // "idle", "unknown", "disabled", "loading", "running", "some_loading", "errored", "all_disabled", "empty"
+        "class": "", // "error", "warn", "soft", ""
+        "message": "", // User-facing English text
+        "any_loading": false
+    },
+    "supported_features": ["feature_id1", "feature_id2"]
 ```
 
 ## HTTP Route /API/GetServerResourceInfo

--- a/src/WebAPI/AdminAPI.cs
+++ b/src/WebAPI/AdminAPI.cs
@@ -45,6 +45,7 @@ public static class AdminAPI
         API.RegisterAPICall(AdminEditRole, true, Permissions.ConfigureRoles);
         API.RegisterAPICall(AdminDeleteRole, true, Permissions.ConfigureRoles);
         API.RegisterAPICall(AdminListPermissions, false, Permissions.ConfigureRoles);
+        API.RegisterAPICall(GetGlobalStatus, false, Permissions.ReadServerInfoPanels);
     }
 
     public static JObject AutoConfigToParamData(AutoConfiguration config, bool hideRestricted = false)
@@ -1033,5 +1034,52 @@ public static class AdminAPI
             };
         }
         return new JObject() { ["permissions"] = permissions, ["ordered"] = JArray.FromObject(Permissions.OrderedKeys) };
+    }
+
+    [API.APIDescription("Get global server-wide generation status across all sessions.",
+        """
+            "status": {
+                "waiting_gens": 0,
+                "loading_models": 0,
+                "waiting_backends": 0,
+                "live_gens": 0
+            },
+            "backend_status": {
+                "status": "running", // "idle", "unknown", "disabled", "loading", "running", "some_loading", "errored", "all_disabled", "empty"
+                "class": "", // "error", "warn", "soft", ""
+                "message": "", // User-facing English text
+                "any_loading": false
+            },
+            "supported_features": ["feature_id1", "feature_id2"]
+        """)]
+    public static async Task<JObject> GetGlobalStatus(Session session)
+    {
+        JObject backendStatus = Program.Backends.CurrentBackendStatus.GetValue();
+        string[] features = [.. Program.Backends.GetAllSupportedFeatures()];
+        Interlocked.MemoryBarrier();
+        int totalWaitingGens = 0;
+        int totalLoadingModels = 0;
+        int totalWaitingBackends = 0;
+        int totalLiveGens = 0;
+        foreach (Session sess in Program.Sessions.Sessions.Values)
+        {
+            totalWaitingGens += sess.WaitingGenerations;
+            totalLoadingModels += sess.LoadingModels;
+            totalWaitingBackends += sess.WaitingBackends;
+            totalLiveGens += sess.LiveGens;
+        }
+        JObject stats = new()
+        {
+            ["waiting_gens"] = totalWaitingGens,
+            ["loading_models"] = totalLoadingModels,
+            ["waiting_backends"] = totalWaitingBackends,
+            ["live_gens"] = totalLiveGens
+        };
+        return new JObject
+        {
+            ["status"] = stats,
+            ["backend_status"] = backendStatus,
+            ["supported_features"] = new JArray(features)
+        };
     }
 }


### PR DESCRIPTION
Background:

I was working on a script which would use the SwarmUI API to fetch current generation count, and based on generation queue length and configured settings, would automatically search VastAI for GPU instances, setup and rent them, connect to them through secure SSH tunnel, and create backends for them using the SwarmUI API. They would also get automatically stopped and eventually destroyed if left unused for too long (configurable), along with the backends. The current SwarmUI API works well for managing the backends, but the GetCurrentStatus API call only returns the current session's generation counts, while the script would need the global counts to handle the backend scaling properly.

This PR:

I added GetGlobalStatus to AdminAPI for getting similar stats as GetCurrentStatus, but summed across all sessions. Also I ran the API doc regeneration and updated the doc files. In addition to the method I added, the other API docs were outdated too, so I pushed the updates to them in a separate commit. I can remove the other API doc update commit from the PR if you want to update them seperately.

This was just a quick way to have a working solution to test my script with, and it does work well with the script. But we can also discuss other ways to implement global generation status information to the API if you'd like a different solution. The script still has some bugs and needs some work before I can release it publicly, but already successfully automatically rents and configures instances for use with SwarmUI and generating with the instances is working.