### PR TITLE
Scrollable model browser header bar

### DIFF
--- a/src/wwwroot/css/genpage.css
+++ b/src/wwwroot/css/genpage.css
@@ -778,7 +778,7 @@ body {
     width: calc(100% - 1rem);
     height: 2.5rem;
     display: block;
-    overflow-x: scroll;
+    overflow-x: auto;
     overflow-y: hidden;
     margin-left: 0.5rem;
 }

--- a/src/wwwroot/css/genpage.css
+++ b/src/wwwroot/css/genpage.css
@@ -778,7 +778,8 @@ body {
     width: calc(100% - 1rem);
     height: 2.5rem;
     display: block;
-    overflow: hidden;
+    overflow-x: scroll;
+    overflow-y: hidden;
     margin-left: 0.5rem;
 }
 .browser-header-count {


### PR DESCRIPTION
For https://github.com/mcmonkeyprojects/SwarmUI/issues/952, though not implemented in the way suggested in the issue.

---

__Behavior before (not scrollable, as you already know):__
<img width="1357" height="213" alt="image" src="https://github.com/user-attachments/assets/42c0040f-1482-4172-9ec1-5601a983da37" />

__Behavior after (scrollable):__  
_Firefox_

https://github.com/user-attachments/assets/537f98d5-96b2-42d8-a846-68762d956971

_Chromium_

https://github.com/user-attachments/assets/6c7a2301-8bad-4941-9f2d-30cafd61728c

---

The main difference between Firefox and Chromium (and their forks, I assume) is that the scrollbar does not hide itself on Chromium, which it does on Firefox. On Chromium, it also seems to make the header bar slightly taller to accommodate the new scrollbar, which it doesn't in Firefox (presumably due to it auto-hiding).