### PR TITLE
Highlight current selected image, move to next/previous on delete

### DIFF
--- a/src/wwwroot/css/genpage.css
+++ b/src/wwwroot/css/genpage.css
@@ -343,6 +343,9 @@ body {
 .image-block-failed::after {
     transform: rotate(-45deg);
 }
+.image-block.image-block-current {
+    outline: 3px solid var(--box-selected-border-stronger);
+}
 .image-batch-0 {
     background-color: var(--batch-0);
 }

--- a/src/wwwroot/css/themes/modern.css
+++ b/src/wwwroot/css/themes/modern.css
@@ -499,9 +499,6 @@
     background: rgba(0, 0, 0, 0.2) !important;
     border: 1px solid var(--box-selected-border-stronger);
 }
-.image-block.image-block-current {
-    outline: 3px solid var(--box-selected-border-stronger);
-}
 
 .model-block {
     border-radius: 10px;

--- a/src/wwwroot/css/themes/modern.css
+++ b/src/wwwroot/css/themes/modern.css
@@ -500,7 +500,7 @@
     border: 1px solid var(--box-selected-border-stronger);
 }
 .image-block.image-block-current {
-    outline: 3px solid color-mix(in srgb, var(--emphasis) 70%, white);
+    outline: 3px solid var(--box-selected-border-stronger);
 }
 
 .model-block {

--- a/src/wwwroot/css/themes/modern.css
+++ b/src/wwwroot/css/themes/modern.css
@@ -499,6 +499,9 @@
     background: rgba(0, 0, 0, 0.2) !important;
     border: 1px solid var(--box-selected-border-stronger);
 }
+.image-block.image-block-current {
+    outline: 3px solid color-mix(in srgb, var(--emphasis) 70%, white);
+}
 
 .model-block {
     border-radius: 10px;

--- a/src/wwwroot/js/genpage/gentab/currentimagehandler.js
+++ b/src/wwwroot/js/genpage/gentab/currentimagehandler.js
@@ -308,7 +308,6 @@ function clickImageInBatch(div) {
 
 /** Removes a preview thumbnail and highlights either next or previous image. */
 function removeImageBlockFromBatch(div) {
-    /** Current image isn't the highlighted one, so just remove it. */
     if (!div.classList.contains('image-block-current')) {
         div.remove();
         return;
@@ -908,7 +907,7 @@ function setCurrentImage(src, metadata = '', batchId = '', previewGrow = false, 
         curImg.appendChild(extrasWrapper);
     }
 
-    /** If switching the main image, we want to update the image preview  as well. */
+    // If switching the main image, we want to update the image preview  as well.
     let batchContainer = getRequiredElementById('current_image_batch');
     if (batchContainer) {
         let batchImg = batchContainer.querySelector(`[data-src="${src}"]`);

--- a/src/wwwroot/js/genpage/gentab/currentimagehandler.js
+++ b/src/wwwroot/js/genpage/gentab/currentimagehandler.js
@@ -306,6 +306,23 @@ function clickImageInBatch(div) {
     setCurrentImage(div.dataset.src, div.dataset.metadata, div.dataset.batch_id ?? '', imgElem && imgElem.dataset.previewGrow == 'true', false, true, div.dataset.is_placeholder == 'true');
 }
 
+// Removes a batch thumbnail and reassigns the 'image-block-current' class appropriately within its container
+function removeImageBlockFromBatch(div) {
+    if (!div.classList.contains('image-block-current')) {
+        div.remove();
+        return;
+    }
+
+    let chosen = div.previousElementSibling || div.nextElementSibling;
+    div.remove();
+
+    if (!chosen) {
+        return;
+    }
+
+    setCurrentImage(chosen.dataset.src, chosen.dataset.metadata, chosen.dataset.batch_id, true);
+}
+
 function rightClickImageInBatch(e, div) {
     if (e.shiftKey || e.ctrlKey) {
         return;
@@ -322,7 +339,7 @@ function rightClickImageInBatch(e, div) {
             popoverActions.push({ key: added.label, action: added.onclick, title: added.title });
         }
     }
-    popoverActions.push({ key: 'Remove From Batch View', action: () => div.remove() })
+    popoverActions.push({ key: 'Remove From Batch View', action: () => removeImageBlockFromBatch(div) })
     let popover = new AdvancedPopover('image_batch_context_menu', popoverActions, false, mouseX, mouseY, document.body, null);
     e.preventDefault();
     e.stopPropagation();
@@ -478,7 +495,7 @@ function shiftToNextImagePreview(next = true, expand = false) {
 
 window.addEventListener('keydown', function(kbevent) {
     let isFullView = imageFullView.isOpen();
-    let isCurImgFocused = document.activeElement && 
+    let isCurImgFocused = document.activeElement &&
         (findParentOfClass(document.activeElement, 'current_image')
         || findParentOfClass(document.activeElement, 'current_image_batch')
         || document.activeElement.tagName == 'BODY');
@@ -892,6 +909,21 @@ function setCurrentImage(src, metadata = '', batchId = '', previewGrow = false, 
     if (!isReuse) {
         curImg.appendChild(img);
         curImg.appendChild(extrasWrapper);
+    }
+
+    // search #current_image_batch for element with data-batch_id == batchId
+    let batchContainer = getRequiredElementById('current_image_batch');
+    let batchImg = batchContainer.querySelector(`[data-batch_id="${batchId}"]`);
+
+    if (batchImg) {
+        [...batchContainer.getElementsByClassName('image-block')].forEach(i => {
+            if (i === batchImg) {
+              i.classList.add('image-block-current');
+              return;
+            }
+
+            i.classList.remove('image-block-current')
+        });
     }
 }
 

--- a/src/wwwroot/js/genpage/gentab/currentimagehandler.js
+++ b/src/wwwroot/js/genpage/gentab/currentimagehandler.js
@@ -907,14 +907,14 @@ function setCurrentImage(src, metadata = '', batchId = '', previewGrow = false, 
         curImg.appendChild(extrasWrapper);
     }
 
-    // If switching the main image, we want to update the image preview  as well.
     let batchContainer = getRequiredElementById('current_image_batch');
     if (batchContainer) {
         let batchImg = batchContainer.querySelector(`[data-src="${src}"]`);
         for (const i of batchContainer.getElementsByClassName('image-block')) {
             if (batchImg && batchImg == i) {
                 i.classList.add('image-block-current');
-            } else {
+            }
+            else {
                 i.classList.remove('image-block-current');
             }
         }

--- a/src/wwwroot/js/genpage/gentab/currentimagehandler.js
+++ b/src/wwwroot/js/genpage/gentab/currentimagehandler.js
@@ -912,7 +912,7 @@ function setCurrentImage(src, metadata = '', batchId = '', previewGrow = false, 
     if (batchContainer) {
         let batchImg = batchContainer.querySelector(`[data-src="${src}"]`);
         [...batchContainer.getElementsByClassName('image-block')].forEach(i => {
-            if (batchImg && batchImg === i) {
+            if (batchImg && batchImg == i) {
               i.classList.add('image-block-current');
               return;
             }

--- a/src/wwwroot/js/genpage/gentab/currentimagehandler.js
+++ b/src/wwwroot/js/genpage/gentab/currentimagehandler.js
@@ -911,13 +911,13 @@ function setCurrentImage(src, metadata = '', batchId = '', previewGrow = false, 
     let batchContainer = getRequiredElementById('current_image_batch');
     if (batchContainer) {
         let batchImg = batchContainer.querySelector(`[data-src="${src}"]`);
-        [...batchContainer.getElementsByClassName('image-block')].forEach(i => {
+        for (const i of batchContainer.getElementsByClassName('image-block')) {
             if (batchImg && batchImg == i) {
-              i.classList.add('image-block-current');
-              return;
+                i.classList.add('image-block-current');
+            } else {
+                i.classList.remove('image-block-current');
             }
-            i.classList.remove('image-block-current')
-        });
+        }
     }
 }
 

--- a/src/wwwroot/js/genpage/gentab/currentimagehandler.js
+++ b/src/wwwroot/js/genpage/gentab/currentimagehandler.js
@@ -911,13 +911,12 @@ function setCurrentImage(src, metadata = '', batchId = '', previewGrow = false, 
         curImg.appendChild(extrasWrapper);
     }
 
-    // search #current_image_batch for element with data-batch_id == batchId
+    // search #current_image_batch for element with data-src == src
     let batchContainer = getRequiredElementById('current_image_batch');
-    let batchImg = batchContainer.querySelector(`[data-batch_id="${batchId}"]`);
-
-    if (batchImg) {
+    if (batchContainer) {
+        let batchImg = batchContainer.querySelector(`[data-src="${src}"]`);
         [...batchContainer.getElementsByClassName('image-block')].forEach(i => {
-            if (i === batchImg) {
+            if (batchImg && batchImg === i) {
               i.classList.add('image-block-current');
               return;
             }

--- a/src/wwwroot/js/genpage/gentab/currentimagehandler.js
+++ b/src/wwwroot/js/genpage/gentab/currentimagehandler.js
@@ -306,21 +306,18 @@ function clickImageInBatch(div) {
     setCurrentImage(div.dataset.src, div.dataset.metadata, div.dataset.batch_id ?? '', imgElem && imgElem.dataset.previewGrow == 'true', false, true, div.dataset.is_placeholder == 'true');
 }
 
-// Removes a batch thumbnail and reassigns the 'image-block-current' class appropriately within its container
+/** Removes a preview thumbnail and highlights either next or previous image. */
 function removeImageBlockFromBatch(div) {
+    /** Current image isn't the highlighted one, so just remove it. */
     if (!div.classList.contains('image-block-current')) {
         div.remove();
         return;
     }
-
     let chosen = div.previousElementSibling || div.nextElementSibling;
     div.remove();
-
-    if (!chosen) {
-        return;
+    if (chosen) {
+        setCurrentImage(chosen.dataset.src, chosen.dataset.metadata, chosen.dataset.batch_id, true);
     }
-
-    setCurrentImage(chosen.dataset.src, chosen.dataset.metadata, chosen.dataset.batch_id, true);
 }
 
 function rightClickImageInBatch(e, div) {
@@ -911,7 +908,7 @@ function setCurrentImage(src, metadata = '', batchId = '', previewGrow = false, 
         curImg.appendChild(extrasWrapper);
     }
 
-    // search #current_image_batch for element with data-src == src
+    /** If switching the main image, we want to update the image preview  as well. */
     let batchContainer = getRequiredElementById('current_image_batch');
     if (batchContainer) {
         let batchImg = batchContainer.querySelector(`[data-src="${src}"]`);
@@ -920,7 +917,6 @@ function setCurrentImage(src, metadata = '', batchId = '', previewGrow = false, 
               i.classList.add('image-block-current');
               return;
             }
-
             i.classList.remove('image-block-current')
         });
     }

--- a/src/wwwroot/js/genpage/gentab/currentimagehandler.js
+++ b/src/wwwroot/js/genpage/gentab/currentimagehandler.js
@@ -306,7 +306,7 @@ function clickImageInBatch(div) {
     setCurrentImage(div.dataset.src, div.dataset.metadata, div.dataset.batch_id ?? '', imgElem && imgElem.dataset.previewGrow == 'true', false, true, div.dataset.is_placeholder == 'true');
 }
 
-/** Removes a preview thumbnail and highlights either next or previous image. */
+/** Removes a preview thumbnail and moves to either previous or next image. */
 function removeImageBlockFromBatch(div) {
     if (!div.classList.contains('image-block-current')) {
         div.remove();
@@ -906,12 +906,11 @@ function setCurrentImage(src, metadata = '', batchId = '', previewGrow = false, 
         curImg.appendChild(img);
         curImg.appendChild(extrasWrapper);
     }
-
     let batchContainer = getRequiredElementById('current_image_batch');
     if (batchContainer) {
         let batchImg = batchContainer.querySelector(`[data-src="${src}"]`);
-        for (const i of batchContainer.getElementsByClassName('image-block')) {
-            if (batchImg && batchImg == i) {
+        for (let i of batchContainer.getElementsByClassName('image-block')) {
+            if (batchImg == i) {
                 i.classList.add('image-block-current');
             }
             else {

--- a/src/wwwroot/js/genpage/gentab/imagehistory.js
+++ b/src/wwwroot/js/genpage/gentab/imagehistory.js
@@ -113,7 +113,7 @@ function buttonsForImage(fullsrc, src, metadata) {
                     }
                     div = getRequiredElementById('current_image_batch').querySelector(`.image-block[data-src="${src}"]`);
                     if (div) {
-                        div.remove();
+                        removeImageBlockFromBatch(div);
                     }
                     let currentImage = document.getElementById('current_image_img');
                     if (currentImage && currentImage.dataset.src == src) {


### PR DESCRIPTION
~This is a draft while I gather feedback.~

Ready for review.

---

# What this does

* Adds an _outline_ to the currently selected image in the `#current_image_batch` container
  * outline was chosen as it does not affect surrounding elements like a border does
* On no previous image, highlights the first image
* On image delete/remove from batch view, automatically highlights the _next_ image. If no next image exists, highlights the _previous_ image. If no images exist, noop
* Works with Image History

# What remains

* ✅ ~Updating all themes with new `.image-block-current` class~
* Implementing feedback regarding color choice, outline thickness, etc
* ✅ ~Making this work with Image History~

https://github.com/user-attachments/assets/c0925e78-66b4-408f-9474-29748a747c1b

Image History:

https://github.com/user-attachments/assets/eaab14e8-b390-4bc9-9e0d-bb58f549a064

