### PR TITLE
Add !important to primary btn text color

### DIFF
--- a/src/wwwroot/css/site.css
+++ b/src/wwwroot/css/site.css
@@ -574,7 +574,7 @@ textarea, input, select {
 }
 .basic-button.btn-primary {
     background-color: var(--emphasis);
-    color: var(--emphasis-text);
+    color: var(--emphasis-text) !important;
 }
 .basic-button:hover {
     background-color: var(--button-background-hover);


### PR DESCRIPTION
Properly applies the correct text color for emphasis buttons.

Before:
<img width="533" height="355" alt="image" src="https://github.com/user-attachments/assets/6535c62b-7104-406c-b203-f89b2f7377ff" />
After:
<img width="536" height="387" alt="image" src="https://github.com/user-attachments/assets/176594ff-7dd5-40dc-86d1-92adaa2b71db" />

Sorry for not checking this thoroughly enough in https://github.com/mcmonkeyprojects/SwarmUI/commit/0c3c916a7aae4b3fa0a9cf59b4dc266924197119...

_Edit: Errr, I guess I could've put this in https://github.com/mcmonkeyprojects/SwarmUI/pull/1034 since it's related to changes made in the Catppuccin themes PR_