### PR TITLE
Live previews for Full View image, bug fixes, and new mode for AutoSwap images

### DIFF
--- a/src/Core/Settings.cs
+++ b/src/Core/Settings.cs
@@ -409,8 +409,9 @@ public class Settings : AutoConfiguration
         [ConfigComment("If true, images in the main center area will always grow to better fill the screen.")]
         public bool CenterImageAlwaysGrow = false; // TODO: UserUI
 
-        [ConfigComment("If true, when 'Auto Swap To Images' is enabled, and you have FullView open, the FullView will also be swapped.\nIf false, the FullView will not change.")]
-        public bool AutoSwapImagesIncludesFullView = false; // TODO: UserUI
+        [ConfigComment("If 'Always', when 'Auto Swap To Images' is enabled, and you have FullView open, the FullView will also be swapped.\nIf 'Never', the FullView will not change.\nIf 'From Newest Only', the FullView will only change if you are viewing the newest image, and a newer image arrives.")]
+        [ManualSettingsOptions(ManualNames = ["Never", "Always", "From Newest Only"], Vals = ["false", "true", "from_newest_only"])]
+        public string AutoSwapImagesIncludesFullView = "false"; // TODO: UserUI
 
         [ConfigComment("A list of what buttons to include directly under images in the main prompt area of the Generate tab.\nOther buttons will be moved into the 'More' dropdown.\nThis should be a comma separated list."
             + "\nThe following options are available: \"Use As Init\", \"Use As Image Prompt\", \"Edit Image\", \"Upscale 2x\", \"Star\", \"Reuse Parameters\", \"Open In Folder\", \"Delete\", \"Download\" \"View In History\", \"Refine Image\""

--- a/src/wwwroot/js/genpage/gentab/currentimagehandler.js
+++ b/src/wwwroot/js/genpage/gentab/currentimagehandler.js
@@ -984,6 +984,32 @@ function appendImage(container, imageSrc, batchId, textPreview, metadata = '', t
     return div;
 }
 
+function wantToSwapFullView() {
+    if (!imageFullView.isOpen()) {
+        return false;
+    }
+    let autoSwapSetting = getUserSetting('AutoSwapImagesIncludesFullView');
+    if (autoSwapSetting === 'true') {
+        return true;
+    }
+    else if (autoSwapSetting === 'false' || autoSwapSetting === 'from_newest_only') {
+        //even when false, still need to auto-swap from unfinished image to finished version of the same image
+        let batch_area = getRequiredElementById('current_image_batch');
+        let imgs = [...batch_area.getElementsByTagName('img')].filter(i => findParentOfClass(i, 'image-block-placeholder') == null);
+        let limit = Math.min(imgs.length, 2);
+        if (autoSwapSetting === 'false') {
+            limit = Math.min(imgs.length, 1);
+        }
+        for (i = 0; i < limit; i++) {
+            let block = findParentOfClass(imgs[i], 'image-block');
+            if (block.dataset.batch_id === imageFullView.currentBatchId) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 function gotImageResult(image, metadata, batchId) {
     updateGenCount();
     let src = image;
@@ -993,7 +1019,7 @@ function gotImageResult(image, metadata, batchId) {
     batch_div.addEventListener('contextmenu', (e) => rightClickImageInBatch(e, batch_div));
     if (!document.getElementById('current_image_img') || autoLoadImagesElem.checked) {
         setCurrentImage(src, metadata, batchId, false, true);
-        if (getUserSetting('AutoSwapImagesIncludesFullView') && imageFullView.isOpen()) {
+        if (wantToSwapFullView()) {
             imageFullView.showImage(src, metadata, batchId);
         }
     }

--- a/src/wwwroot/js/genpage/gentab/currentimagehandler.js
+++ b/src/wwwroot/js/genpage/gentab/currentimagehandler.js
@@ -198,6 +198,7 @@ class ImageFullViewHelper {
                 ${formatMetadata(metadata)}
             </div>
         </div>`;
+        this.imgElement = document.getElementById("imageview_popup_modal_img");
         let subDiv = this.content.querySelector('.image_fullview_extra_buttons');
         for (let added of buttonsForImage(getImageFullSrc(src), src, metadata)) {
             if (added.href) {

--- a/src/wwwroot/js/genpage/gentab/currentimagehandler.js
+++ b/src/wwwroot/js/genpage/gentab/currentimagehandler.js
@@ -177,9 +177,10 @@ class ImageFullViewHelper {
         img.style.height = `${newHeight}%`;
     }
 
-    showImage(src, metadata) {
+    showImage(src, metadata, batchId) {
         this.currentSrc = src;
         this.currentMetadata = metadata;
+        this.currentBatchId = batchId;
         let isVideo = isVideoExt(src);
         let encodedSrc = escapeHtmlForUrl(src);
         let imgHtml = `<img class="imageview_popup_modal_img" id="imageview_popup_modal_img" style="cursor:grab;max-width:100%;object-fit:contain;" src="${encodedSrc}">`;
@@ -300,7 +301,7 @@ function toggleSeparateBatches() {
 function clickImageInBatch(div) {
     let imgElem = div.getElementsByTagName('img')[0];
     if (currentImgSrc == div.dataset.src) {
-        imageFullView.showImage(div.dataset.src, div.dataset.metadata);
+        imageFullView.showImage(div.dataset.src, div.dataset.metadata, div.dataset.batch_id);
         return;
     }
     setCurrentImage(div.dataset.src, div.dataset.metadata, div.dataset.batch_id ?? '', imgElem && imgElem.dataset.previewGrow == 'true', false, true, div.dataset.is_placeholder == 'true');
@@ -447,7 +448,7 @@ function shiftToNextImagePreview(next = true, expand = false) {
         divs[newIndex].querySelector('img').click();
         if (expand) {
             divs[newIndex].querySelector('img').click();
-            imageFullView.showImage(currentImgSrc, currentMetadataVal);
+            imageFullView.showImage(currentImgSrc, currentMetadataVal, 'history');
             imageFullView.pasteState(expandedState);
         }
         return;
@@ -471,7 +472,7 @@ function shiftToNextImagePreview(next = true, expand = false) {
     let block = findParentOfClass(newImg, 'image-block');
     setCurrentImage(block.dataset.src, block.dataset.metadata, block.dataset.batch_id, newImg.dataset.previewGrow == 'true');
     if (expand) {
-        imageFullView.showImage(block.dataset.src, block.dataset.metadata);
+        imageFullView.showImage(block.dataset.src, block.dataset.metadata, block.dataset.batch_id);
         imageFullView.pasteState(expandedState);
     }
 }
@@ -576,7 +577,7 @@ function toggleStar(path, rawSrc) {
         if (imageFullView.isOpen() && imageFullView.currentSrc == rawSrc) {
             let oldMetadata = JSON.parse(imageFullView.currentMetadata);
             let newMetadata = { ...oldMetadata, is_starred: data.new_state };
-            imageFullView.showImage(rawSrc, JSON.stringify(newMetadata));
+            imageFullView.showImage(rawSrc, JSON.stringify(newMetadata), imageFullView.currentBatchId);
         }
     });
 }
@@ -981,7 +982,7 @@ function gotImageResult(image, metadata, batchId) {
     if (!document.getElementById('current_image_img') || autoLoadImagesElem.checked) {
         setCurrentImage(src, metadata, batchId, false, true);
         if (getUserSetting('AutoSwapImagesIncludesFullView') && imageFullView.isOpen()) {
-            imageFullView.showImage(src, metadata);
+            imageFullView.showImage(src, metadata, batchId);
         }
     }
     return batch_div;

--- a/src/wwwroot/js/genpage/gentab/currentimagehandler.js
+++ b/src/wwwroot/js/genpage/gentab/currentimagehandler.js
@@ -427,12 +427,23 @@ function copy_current_image_params() {
 }
 
 function shiftToNextImagePreview(next = true, expand = false) {
-    let curImgElem = document.getElementById('current_image_img');
+    let batchId;
+    let curImgElem;
+    let isExpanded = imageFullView.isOpen();
+    if (!isExpanded) {
+        curImgElem = document.getElementById('current_image_img');
+        batchId = curImgElem.dataset.batch_id;
+    }
+    else {
+        curImgElem = imageFullView.imgElement;
+        batchId = imageFullView.currentBatchId;
+    }
+    
     if (!curImgElem) {
         return;
     }
-    let expandedState = imageFullView.isOpen() ? imageFullView.copyState() : {};
-    if (curImgElem.dataset.batch_id == 'history') {
+    let expandedState = isExpanded ? imageFullView.copyState() : {};
+    if (batchId == 'history') {
         let divs = [...lastHistoryImageDiv.parentElement.children].filter(div => div.classList.contains('image-block'));
         let index = divs.findIndex(div => div == lastHistoryImageDiv);
         if (index == -1) {

--- a/src/wwwroot/js/genpage/gentab/currentimagehandler.js
+++ b/src/wwwroot/js/genpage/gentab/currentimagehandler.js
@@ -571,13 +571,15 @@ function toggleStar(path, rawSrc) {
             let newMetadata = { ...oldMetadata, is_starred: data.new_state };
             curImgImg.dataset.metadata = JSON.stringify(newMetadata);
             let button = getRequiredElementById('current_image').querySelector('.star-button');
-            if (data.new_state) {
-                button.classList.add('button-starred-image');
-                button.innerText = 'Starred';
-            }
-            else {
-                button.classList.remove('button-starred-image');
-                button.innerText = 'Star';
+            if (button) {
+                if (data.new_state) {
+                    button.classList.add('button-starred-image');
+                    button.innerText = 'Starred';
+                }
+                else {
+                    button.classList.remove('button-starred-image');
+                    button.innerText = 'Star';
+                }
             }
         }
         let batchDiv = getRequiredElementById('current_image_batch').querySelector(`.image-block[data-src="${rawSrc}"]`);

--- a/src/wwwroot/js/genpage/gentab/currentimagehandler.js
+++ b/src/wwwroot/js/genpage/gentab/currentimagehandler.js
@@ -469,6 +469,10 @@ function shiftToNextImagePreview(next = true, expand = false) {
     let imgs = [...batch_area.getElementsByTagName('img')].filter(i => findParentOfClass(i, 'image-block-placeholder') == null);
     let index = imgs.findIndex(img => img.src == curImgElem.src);
     if (index == -1) {
+		//second chance in case we are at a preview and it failed to switch to the final image, allow it to find the current image by batch id instead
+		index = imgs.findIndex(img => findParentOfClass(img, 'image-block').dataset.batch_id == batchId);
+	}
+    if (index == -1) {
         let cleanSrc = (img) => img.src.length > 100 ? img.src.substring(0, 100) + '...' : img.src;
         console.log(`Image preview shift failed as current image ${cleanSrc(curImgElem)} is not in batch area set ${imgs.map(cleanSrc)}`);
         return;

--- a/src/wwwroot/js/genpage/helpers/generatehandler.js
+++ b/src/wwwroot/js/genpage/helpers/generatehandler.js
@@ -196,7 +196,9 @@ class GenerateHandler {
                     let curImgElem = document.getElementById(this.imageId);
                     if (data.gen_progress.preview && (!imgHolder.image || data.gen_progress.preview != imgHolder.image)) {
                         if (curImgElem && curImgElem.dataset.batch_id == thisBatchId) {
-                            curImgElem.src = data.gen_progress.preview;
+                            currentImgSrc = data.gen_progress.preview;
+                            curImgElem.src = currentImgSrc;
+                            curImgElem.dataset.src = currentImgSrc;
                         }
                         this.setImageFor(imgHolder, data.gen_progress.preview);
                     }

--- a/src/wwwroot/js/genpage/helpers/generatehandler.js
+++ b/src/wwwroot/js/genpage/helpers/generatehandler.js
@@ -202,6 +202,10 @@ class GenerateHandler {
                         }
                         this.setImageFor(imgHolder, data.gen_progress.preview);
                     }
+                    if (data.gen_progress.preview && imageFullView.isOpen() && imageFullView.imgElement && imageFullView.currentBatchId == thisBatchId)
+                    {
+                        imageFullView.imgElement.src = data.gen_progress.preview;
+                    }
                 }
             }
             this.gotProgress(data.gen_progress.current_percent, data.gen_progress.overall_percent, thisBatchId);

--- a/src/wwwroot/js/genpage/helpers/generatehandler.js
+++ b/src/wwwroot/js/genpage/helpers/generatehandler.js
@@ -141,9 +141,10 @@ class GenerateHandler {
                 let imgHolder = images[data.batch_index];
                 let curImgElem = document.getElementById(this.imageId);
                 if (!curImgElem || autoLoadImagesElem.checked || curImgElem.dataset.batch_id == `${data.request_id}_${data.batch_index}`) {
-                    this.setCurrentImage(data.image, data.metadata, `${data.request_id}_${data.batch_index}`, false, true);
+                    let batchId = `${data.request_id}_${data.batch_index}`;
+                    this.setCurrentImage(data.image, data.metadata, batchId, false, true);
                     if (getUserSetting('AutoSwapImagesIncludesFullView') && imageFullView.isOpen()) {
-                        imageFullView.showImage(data.image, data.metadata);
+                        imageFullView.showImage(data.image, data.metadata, batchId);
                     }
                 }
                 let imgElem = imgHolder.div.querySelector('img');

--- a/src/wwwroot/js/genpage/helpers/generatehandler.js
+++ b/src/wwwroot/js/genpage/helpers/generatehandler.js
@@ -143,7 +143,7 @@ class GenerateHandler {
                 if (!curImgElem || autoLoadImagesElem.checked || curImgElem.dataset.batch_id == `${data.request_id}_${data.batch_index}`) {
                     let batchId = `${data.request_id}_${data.batch_index}`;
                     this.setCurrentImage(data.image, data.metadata, batchId, false, true);
-                    if (getUserSetting('AutoSwapImagesIncludesFullView') && imageFullView.isOpen()) {
+                    if (wantToSwapFullView()) {
                         imageFullView.showImage(data.image, data.metadata, batchId);
                     }
                 }


### PR DESCRIPTION
This PR makes the following changes:

* Added live previews for Full View images.
* Fixed several bugs when opening a preview image:
  * There was a bug where you had to rapidly click on the Current Image or Batch Image in order to open the Full View.  Normally you click once to select the image, then click a second time to open the Full View.  But it was failing to open the Full View if a preview arrived while the image was selected, instead re-selecting the image.  Opening a Full View required you to click rapidly.
  * Opening the Full View opened a stale preview image rather than the most recent iteration of the preview
* Changes to prevent you from losing your place when navigating Full View images:
  * Previously, when a new image arrived, your movement cursor was reset back to the leftmost image.  This changes it so that your currently viewed image in Full View mode is used instead of the Current Image.
  * New feature: Option to only swap to new images in Full View if we are looking at the newest completed image.  This allows you to watch new images come in, but also move right and left without losing your place.  When you want new images again, move to either the newest completed gen, or the current preview.
* Also fixes an exception when you star an image, but you removed the star button via user settings.

Related issue: #1042