### PR TITLE
Fix several bugs when opening a preview image

### DIFF
--- a/src/wwwroot/js/genpage/helpers/generatehandler.js
+++ b/src/wwwroot/js/genpage/helpers/generatehandler.js
@@ -195,7 +195,9 @@ class GenerateHandler {
                     let curImgElem = document.getElementById(this.imageId);
                     if (data.gen_progress.preview && (!imgHolder.image || data.gen_progress.preview != imgHolder.image)) {
                         if (curImgElem && curImgElem.dataset.batch_id == thisBatchId) {
-                            curImgElem.src = data.gen_progress.preview;
+                            currentImgSrc = data.gen_progress.preview;
+                            curImgElem.src = currentImgSrc;
+                            curImgElem.dataset.src = currentImgSrc;
                         }
                         this.setImageFor(imgHolder, data.gen_progress.preview);
                     }


### PR DESCRIPTION
Fixes several bugs when opening a preview image:

* Bug where you had to rapidly click on the Current Image or Batch Image in order to open the Full View.

Function `clickImageInBatch` from `currentimagehandler.js` was checking `currentImgSrc == div.dataset.src`.  This gets out of sync when a new preview arrives.  The thumbnail on the Batch View on the right side has updated its img src, the Current Image in the center panel has updates its img src, but the `currentImgSrc` property is out of date. This makes it so that you try to click once to display in Full View, but it doesn't open it, instead it sees that the image isn't the same, so it uses your click to re-select the image.

* Bug where opening the Full View opened a stale preview image rather than the most recent iteration of the preview.

Function `setCurrentImage` uses this code to determine which image to load in Full View: `imageFullView.showImage(img.dataset.src, img.dataset.metadata)`.  It wants to take the image from `img.dataset.src`.  This variable `img.dataset.src` is only assigned once before the final image arrives, and that's when the first preview arrives.  This means that any attempt to open the Full View instead loads the first preview that arrived.

This changes the code to update `currentImgSrc`, `curImgElem.src` and `curImgElem.dataset.src` all at the same time when a new preview arrives, fixing those issues.