### PR TITLE
Add live previews to the Full View

### DIFF
--- a/src/wwwroot/js/genpage/gentab/currentimagehandler.js
+++ b/src/wwwroot/js/genpage/gentab/currentimagehandler.js
@@ -177,9 +177,10 @@ class ImageFullViewHelper {
         img.style.height = `${newHeight}%`;
     }
 
-    showImage(src, metadata) {
+    showImage(src, metadata, batchId) {
         this.currentSrc = src;
         this.currentMetadata = metadata;
+        this.currentBatchId = batchId;
         let isVideo = isVideoExt(src);
         let encodedSrc = escapeHtmlForUrl(src);
         let imgHtml = `<img class="imageview_popup_modal_img" id="imageview_popup_modal_img" style="cursor:grab;max-width:100%;object-fit:contain;" src="${encodedSrc}">`;
@@ -197,6 +198,7 @@ class ImageFullViewHelper {
                 ${formatMetadata(metadata)}
             </div>
         </div>`;
+        this.imgElement = document.getElementById("imageview_popup_modal_img");
         let subDiv = this.content.querySelector('.image_fullview_extra_buttons');
         for (let added of buttonsForImage(getImageFullSrc(src), src, metadata)) {
             if (added.href) {
@@ -300,7 +302,7 @@ function toggleSeparateBatches() {
 function clickImageInBatch(div) {
     let imgElem = div.getElementsByTagName('img')[0];
     if (currentImgSrc == div.dataset.src) {
-        imageFullView.showImage(div.dataset.src, div.dataset.metadata);
+        imageFullView.showImage(div.dataset.src, div.dataset.metadata, div.dataset.batch_id);
         return;
     }
     setCurrentImage(div.dataset.src, div.dataset.metadata, div.dataset.batch_id ?? '', imgElem && imgElem.dataset.previewGrow == 'true', false, true, div.dataset.is_placeholder == 'true');
@@ -447,7 +449,7 @@ function shiftToNextImagePreview(next = true, expand = false) {
         divs[newIndex].querySelector('img').click();
         if (expand) {
             divs[newIndex].querySelector('img').click();
-            imageFullView.showImage(currentImgSrc, currentMetadataVal);
+            imageFullView.showImage(currentImgSrc, currentMetadataVal, 'history');
             imageFullView.pasteState(expandedState);
         }
         return;
@@ -471,7 +473,7 @@ function shiftToNextImagePreview(next = true, expand = false) {
     let block = findParentOfClass(newImg, 'image-block');
     setCurrentImage(block.dataset.src, block.dataset.metadata, block.dataset.batch_id, newImg.dataset.previewGrow == 'true');
     if (expand) {
-        imageFullView.showImage(block.dataset.src, block.dataset.metadata);
+        imageFullView.showImage(block.dataset.src, block.dataset.metadata, block.dataset.batch_id);
         imageFullView.pasteState(expandedState);
     }
 }
@@ -576,7 +578,7 @@ function toggleStar(path, rawSrc) {
         if (imageFullView.isOpen() && imageFullView.currentSrc == rawSrc) {
             let oldMetadata = JSON.parse(imageFullView.currentMetadata);
             let newMetadata = { ...oldMetadata, is_starred: data.new_state };
-            imageFullView.showImage(rawSrc, JSON.stringify(newMetadata));
+            imageFullView.showImage(rawSrc, JSON.stringify(newMetadata), imageFullView.currentBatchId);
         }
     });
 }
@@ -691,7 +693,9 @@ function setCurrentImage(src, metadata = '', batchId = '', previewGrow = false, 
     img.dataset.src = src;
     img.dataset.metadata = metadata || '{}';
     img.dataset.batch_id = batchId;
-    img.onclick = () => imageFullView.showImage(img.dataset.src, img.dataset.metadata);
+    img.onclick = () => {
+        imageFullView.showImage(img.dataset.src, img.dataset.metadata, img.dataset.batch_id);
+    }
     let extrasWrapper = isReuse ? document.getElementById('current-image-extras-wrapper') : createDiv('current-image-extras-wrapper', 'current-image-extras-wrapper');
     extrasWrapper.innerHTML = '';
     let buttons = createDiv(null, 'current-image-buttons');
@@ -981,7 +985,7 @@ function gotImageResult(image, metadata, batchId) {
     if (!document.getElementById('current_image_img') || autoLoadImagesElem.checked) {
         setCurrentImage(src, metadata, batchId, false, true);
         if (getUserSetting('AutoSwapImagesIncludesFullView') && imageFullView.isOpen()) {
-            imageFullView.showImage(src, metadata);
+            imageFullView.showImage(src, metadata, batchId);
         }
     }
     return batch_div;

--- a/src/wwwroot/js/genpage/helpers/generatehandler.js
+++ b/src/wwwroot/js/genpage/helpers/generatehandler.js
@@ -143,7 +143,7 @@ class GenerateHandler {
                 if (!curImgElem || autoLoadImagesElem.checked || curImgElem.dataset.batch_id == `${data.request_id}_${data.batch_index}`) {
                     this.setCurrentImage(data.image, data.metadata, `${data.request_id}_${data.batch_index}`, false, true);
                     if (getUserSetting('AutoSwapImagesIncludesFullView') && imageFullView.isOpen()) {
-                        imageFullView.showImage(data.image, data.metadata);
+                        imageFullView.showImage(data.image, data.metadata, `${data.request_id}_${data.batch_index}`);
                     }
                 }
                 let imgElem = imgHolder.div.querySelector('img');
@@ -198,6 +198,10 @@ class GenerateHandler {
                             curImgElem.src = data.gen_progress.preview;
                         }
                         this.setImageFor(imgHolder, data.gen_progress.preview);
+                    }
+                    if (data.gen_progress.preview && imageFullView.isOpen() && imageFullView.imgElement && imageFullView.currentBatchId == thisBatchId)
+                    {
+                        imageFullView.imgElement.src = data.gen_progress.preview;
                     }
                 }
             }


### PR DESCRIPTION
Add live previews to the Full View

In order to support live previews, the Full View must now keep track of the batch ID, so the function `ImageFullViewHelper.showImage` has a new parameter to pass in the batch ID.  This is saved as the `this.currentBatchId` member. The `img` element with id `imageview_popup_modal_img` is also exposed as `this.imgElement`.

With the img element exposed, and the Batch ID now associated with the Full View, the function `GenerateHandler.internalHandleData` can now safely update the Full View's img src when its batch ID matches.

---

I tested out that all calls to `showImage` to see if the batch id was correct.  But there was one I couldn't test, that's the `gotImageResult` function.  I'll have to assume that the `batchId` function parameter that's passed in is correct, since it's also passed to `setCurrentImage`.