### PR TITLE
Prevent exception when starring image if you hid the Star button

### DIFF
--- a/src/wwwroot/js/genpage/gentab/currentimagehandler.js
+++ b/src/wwwroot/js/genpage/gentab/currentimagehandler.js
@@ -554,13 +554,15 @@ function toggleStar(path, rawSrc) {
             let newMetadata = { ...oldMetadata, is_starred: data.new_state };
             curImgImg.dataset.metadata = JSON.stringify(newMetadata);
             let button = getRequiredElementById('current_image').querySelector('.star-button');
-            if (data.new_state) {
-                button.classList.add('button-starred-image');
-                button.innerText = 'Starred';
-            }
-            else {
-                button.classList.remove('button-starred-image');
-                button.innerText = 'Star';
+            if (button) {
+                if (data.new_state) {
+                    button.classList.add('button-starred-image');
+                    button.innerText = 'Starred';
+                }
+                else {
+                    button.classList.remove('button-starred-image');
+                    button.innerText = 'Star';
+                }
             }
         }
         let batchDiv = getRequiredElementById('current_image_batch').querySelector(`.image-block[data-src="${rawSrc}"]`);


### PR DESCRIPTION
Prevent exception when starring an image if the Star button was hidden via User Settings.

Doesn't change the popover menu text though.  "Star" doesn't become "Starred" there.  There's no easy way to access the "Star" button that appears in an AdvancedPopOver, all you have is the DOM.  Seems that you need to call `setCurrentImage` again instead to regenerate the buttons, which I'm not currently doing.