### PR TITLE
use DOM ready event instead of 100ms timer to initialize wildcard modal

### DIFF
--- a/src/wwwroot/js/genpage/gentab/wildcards.js
+++ b/src/wwwroot/js/genpage/gentab/wildcards.js
@@ -23,9 +23,9 @@ class WildcardHelpers {
         this.nameElem.addEventListener('input', () => {
             this.modalMayClose = false;
         });
-        setTimeout(() => {
+        $(() => {
             $(this.modalElem).modal({backdrop: 'static', keyboard: false});
-        }, 100); // This can just be '1' normally, but Chromium is very stupid, so we have to give it time to remember that jquery is in the fucking header.
+        }); // wait for DOMReady event, which is when bootstrap registers its jQuery plugins (like modal)
         $(this.modalElem).on('hidePrevented.bs.modal', () => {
             if (this.modalMayClose) {
                 $(this.modalElem).modal('hide');


### PR DESCRIPTION
so I was still getting the modal method not  defined error about 50% of the time I refreshed the page (my computer can be s.l.o.w sometimes and that 100ms delay wasn't enough to finish loading all the scripts).  Switching to jquery ready event seems to reliably resolve the error.