### PR TITLE
Adds SwarmUI-PromptBuilderExtension

### DIFF
--- a/launchtools/extension_list.fds
+++ b/launchtools/extension_list.fds
@@ -189,7 +189,7 @@ MoreThemes:
 
 PromptBuilder:
     author: Juan Treminio
-    description: Adds a new tool UI to browse clickable Danbooru tags to build your prompt.
+    description: Adds a new tool UI to browse clickable Danbooru tags to build your prompt. Appears under Tools tab dropdown.
     url: https://github.com/jtreminio/SwarmUI-PromptBuilderExtension
     license: MIT
     tags:


### PR DESCRIPTION
Adds a new tool UI to browse clickable Danbooru tags to build your prompt.

The tool appears under "Tools" dropdown, similar to Grid Generator.