### PR TITLE
Keep image modal open on delete

### DIFF
--- a/src/wwwroot/js/genpage/gentab/currentimagehandler.js
+++ b/src/wwwroot/js/genpage/gentab/currentimagehandler.js
@@ -178,6 +178,7 @@ class ImageFullViewHelper {
     }
 
     showImage(src, metadata, batchId = null) {
+        let wasOpen = this.isOpen();
         this.currentSrc = src;
         this.currentMetadata = metadata;
         this.currentBatchId = batchId;
@@ -225,24 +226,26 @@ class ImageFullViewHelper {
                 }
             }
         }
-        if (this.fixButtonDelay) {
-            clearTimeout(this.fixButtonDelay);
-        }
-        if (Date.now() - this.lastClosed > 200) {
-            subDiv.style.pointerEvents = 'none';
-            for (let button of subDiv.getElementsByTagName('button')) {
-                button.disabled = true;
-                button.classList.add('simpler-button-disable');
+        if (!wasOpen) {
+            if (this.fixButtonDelay) {
+                clearTimeout(this.fixButtonDelay);
             }
-            this.fixButtonDelay = setTimeout(() => {
-                if (subDiv && subDiv.parentElement) {
-                    subDiv.style.pointerEvents = 'auto';
-                    for (let button of subDiv.getElementsByTagName('button')) {
-                        button.disabled = false;
-                    }
+            if (Date.now() - this.lastClosed > 200) {
+                subDiv.style.pointerEvents = 'none';
+                for (let button of subDiv.getElementsByTagName('button')) {
+                    button.disabled = true;
+                    button.classList.add('simpler-button-disable');
                 }
-                this.fixButtonDelay = null;
-            }, 500);
+                this.fixButtonDelay = setTimeout(() => {
+                    if (subDiv && subDiv.parentElement) {
+                        subDiv.style.pointerEvents = 'auto';
+                        for (let button of subDiv.getElementsByTagName('button')) {
+                            button.disabled = false;
+                        }
+                    }
+                    this.fixButtonDelay = null;
+                }, 500);
+            }
         }
     }
 

--- a/src/wwwroot/js/genpage/gentab/outputhistory.js
+++ b/src/wwwroot/js/genpage/gentab/outputhistory.js
@@ -98,6 +98,31 @@ function buttonsForImage(fullsrc, src, metadata) {
                 if (!uiImprover.lastShift && getUserSetting('ui.checkifsurebeforedelete', true) && !confirm('Are you sure you want to delete this image?\nHold shift to bypass.')) {
                     return;
                 }
+                let wasFullView = imageFullView && imageFullView.isOpen && imageFullView.isOpen();
+                let curImg = document.getElementById('current_image_img');
+                let keepOpen = false;
+                if (wasFullView && curImg) {
+                    if (curImg.dataset.batch_id == 'history' && lastHistoryImageDiv && lastHistoryImageDiv.parentElement) {
+                        let divs = [...lastHistoryImageDiv.parentElement.children].filter(d => d.classList && d.classList.contains('image-block'));
+                        if (divs.length > 1) {
+                            let index = divs.findIndex(div => div == lastHistoryImageDiv);
+                            let goNext = index == 0;
+                            shiftToNextImagePreview(goNext, true);
+                            keepOpen = true;
+                        }
+                    }
+                    else {
+                        let batchArea = getRequiredElementById('current_image_batch');
+                        let blocks = [...batchArea.getElementsByClassName('image-block')].filter(d => !d.classList.contains('image-block-placeholder'));
+                        if (blocks.length > 1) {
+                            let currentBlock = batchArea.querySelector('.image-block-current');
+                            let index = currentBlock ? blocks.findIndex(b => b == currentBlock) : -1;
+                            let goNext = index == 0;
+                            shiftToNextImagePreview(goNext, true);
+                            keepOpen = true;
+                        }
+                    }
+                }
                 genericRequest('DeleteImage', {'path': fullsrc}, data => {
                     if (e) {
                         e.remove();
@@ -114,6 +139,9 @@ function buttonsForImage(fullsrc, src, metadata) {
                     div = getRequiredElementById('current_image_batch').querySelector(`.image-block[data-src="${src}"]`);
                     if (div) {
                         removeImageBlockFromBatch(div);
+                    }
+                    if (keepOpen) {
+                        return;
                     }
                     let currentImage = document.getElementById('current_image_img');
                     if (currentImage && currentImage.dataset.src == src) {


### PR DESCRIPTION
When viewing an image in the full-screen modal, on Delete, keeps modal open and displays either the next or previous image in batch. If no image, closes modal.

Also has the fun side-effect of keeping existing image zoom on delete :)