### PR TITLE
Adds DeleteImageCycleEnd flag to prevent cycling from ends when deleting image

### DIFF
--- a/src/Core/Settings.cs
+++ b/src/Core/Settings.cs
@@ -390,6 +390,9 @@ public class Settings : AutoConfiguration
 
             [ConfigComment("If true, shifting to next/previous image (eg with arrow keys) in history or batch view,\ncycles at the ends (jumps from the start to the end or vice versa).\nIf false, shifting will simply stop at the ends.")]
             public bool ImageShiftingCycles = true;
+
+            [ConfigComment("If true, deleting an image at the beginning or end of list may cycle to the other end, depending on your selected Delete Image Behavior.\nIf false, will not jump to the other end.")]
+            public bool DeleteImageCycleEnd = true;
         }
 
         [ConfigComment("Settings related to the user interface, entirely contained to the frontend.")]

--- a/src/wwwroot/js/genpage/gentab/currentimagehandler.js
+++ b/src/wwwroot/js/genpage/gentab/currentimagehandler.js
@@ -460,12 +460,13 @@ function copy_current_image_params() {
  * Shifts the current image view (and full-view if open) to the next or previous image.
  * Returns true if the shift was successful, returns false if there was nothing to shift to.
  */
-function shiftToNextImagePreview(next = true, expand = false) {
+function shiftToNextImagePreview(next = true, expand = false, isDeleting = false) {
     let curImgElem = document.getElementById('current_image_img');
     if (!curImgElem) {
         return false;
     }
     let doCycle = getUserSetting('ui.imageshiftingcycles', true);
+    let deleteCycle = getUserSetting('ui.deleteimagecycleend', true);
     let expandedState = imageFullView.isOpen() ? imageFullView.copyState() : {};
     if (curImgElem.dataset.batch_id == 'history') {
         let divs = [...lastHistoryImageDiv.parentElement.children].filter(div => div.classList.contains('image-block'));
@@ -475,17 +476,34 @@ function shiftToNextImagePreview(next = true, expand = false) {
             return false;
         }
         let newIndex = index + (next ? 1 : -1);
+        let shouldCycle = isDeleting ? deleteCycle : doCycle;
         if (newIndex < 0) {
-            if (!doCycle) {
-                return false;
+            if (shouldCycle) {
+                newIndex = divs.length - 1;
+            } else {
+                if (!isDeleting) {
+                    return false;
+                }
+                if (divs.length > 1) {
+                    newIndex = 1;
+                } else {
+                    return false;
+                }
             }
-            newIndex = divs.length - 1;
         }
         else if (newIndex >= divs.length) {
-            if (!doCycle) {
-                return false;
+            if (shouldCycle) {
+                newIndex = 0;
+            } else {
+                if (!isDeleting) {
+                    return false;
+                }
+                if (divs.length > 1) {
+                    newIndex = divs.length - 2;
+                } else {
+                    return false;
+                }
             }
-            newIndex = 0;
         }
         if (newIndex == index) {
             return false;
@@ -507,17 +525,34 @@ function shiftToNextImagePreview(next = true, expand = false) {
         return false;
     }
     let newIndex = index + (next ? 1 : -1);
+    let shouldCycle = isDeleting ? deleteCycle : doCycle;
     if (newIndex < 0) {
-        if (!doCycle) {
-            return false;
+        if (shouldCycle) {
+            newIndex = imgs.length - 1;
+        } else {
+            if (!isDeleting) {
+                return false;
+            }
+            if (imgs.length > 1) {
+                newIndex = 1;
+            } else {
+                return false;
+            }
         }
-        newIndex = imgs.length - 1;
     }
     else if (newIndex >= imgs.length) {
-        if (!doCycle) {
-            return false;
+        if (shouldCycle) {
+            newIndex = 0;
+        } else {
+            if (!isDeleting) {
+                return false;
+            }
+            if (imgs.length > 1) {
+                newIndex = imgs.length - 2;
+            } else {
+                return false;
+            }
         }
-        newIndex = 0;
     }
     if (newIndex == index) {
         return false;

--- a/src/wwwroot/js/genpage/gentab/outputhistory.js
+++ b/src/wwwroot/js/genpage/gentab/outputhistory.js
@@ -99,7 +99,7 @@ function buttonsForImage(fullsrc, src, metadata) {
                     return;
                 }
                 let deleteBehavior = getUserSetting('ui.deleteimagebehavior', 'next');
-                let shifted = deleteBehavior == 'nothing' ? false : shiftToNextImagePreview(deleteBehavior == 'next', imageFullView.isOpen());
+                let shifted = deleteBehavior == 'nothing' ? false : shiftToNextImagePreview(deleteBehavior == 'next', imageFullView.isOpen(), true);
                 if (!shifted) {
                     imageFullView.close();
                 }


### PR DESCRIPTION
Flag ON (default behavior) depending on flag of existing `DeleteImageBehavior` flag:
* `[E, D, C, B, A◄]` Delete A
* `[E◄, D, C, B]` Jumps to E

or,

* `[E◄, D, C, B, A]` Delete E
* `[D, C, B, A◄]` Jumps to A

With flag OFF:
* `[E, D, C, B, A◄]` Delete A
* `[E, D, C, B◄]` Jumps to B

or,

* `[E◄, D, C, B, A]` Delete E
* `[D◄, C, B, A]` Jumps to D

This is separate from the behavior of the `ImageShiftingCycles` - that flag will now decide if you can shift from end to end with left/right arrows. This new `DeleteImageBehavior` flag decides if deleting applies the same behavior.