### PR TITLE
Adds WASD image browse/star/delete functionality

### DIFF
--- a/src/wwwroot/js/genpage/gentab/outputhistory.js
+++ b/src/wwwroot/js/genpage/gentab/outputhistory.js
@@ -95,36 +95,7 @@ function buttonsForImage(fullsrc, src, metadata) {
             label: 'Delete',
             title: 'Deletes this image from the server.',
             onclick: (e) => {
-                if (!uiImprover.lastShift && getUserSetting('ui.checkifsurebeforedelete', true) && !confirm('Are you sure you want to delete this image?\nHold shift to bypass.')) {
-                    return;
-                }
-                let deleteBehavior = getUserSetting('ui.deleteimagebehavior', 'next');
-                let shifted = deleteBehavior == 'nothing' ? false : shiftToNextImagePreview(deleteBehavior == 'next', imageFullView.isOpen());
-                if (!shifted) {
-                    imageFullView.close();
-                }
-                genericRequest('DeleteImage', {'path': fullsrc}, data => {
-                    if (e) {
-                        e.remove();
-                    }
-                    let historySection = getRequiredElementById('imagehistorybrowser-content');
-                    let div = historySection.querySelector(`.image-block[data-name="${fullsrc}"]`);
-                    if (div) {
-                        div.remove();
-                    }
-                    div = historySection.querySelector(`.image-block[data-name="${src}"]`);
-                    if (div) {
-                        div.remove();
-                    }
-                    let currentImage = document.getElementById('current_image_img');
-                    if (currentImage && currentImage.dataset.src == src) {
-                        forceShowWelcomeMessage();
-                    }
-                    div = getRequiredElementById('current_image_batch').querySelector(`.image-block[data-src="${src}"]`);
-                    if (div) {
-                        removeImageBlockFromBatch(div);
-                    }
-                });
+                deleteCurrentImage(e, fullsrc, src);
             }
         });
     }


### PR DESCRIPTION
Adds WASD-based image browsing, star, and delete functionality.

* `W`: LEFT ARROW
* `S`: RIGHT ARROW
* `A`: STAR IMAGE
* `D`: DELETE IMAGE

Deleting the image requires pressing the `D` key twice within 500ms, and not performing any other action from this list in between key presses: `['mousedown', 'wheel', 'scroll', 'touchstart', 'pointerdown', 'contextmenu']`.

We can quickly change what keys map to what action. I realize A/D might be better for LEFT/RIGHT arrow functionality, but D (especially double D) maps to DELETE in vim and D is for delete so 🤷 .

Followup PRs (or maybe add to this one?):

* user-configurable keys - I imagine folks with non-qwerty keyboards might want something else, or someone without a left hand??
* user-configurable timeout - for folks who can't physically press a key twice within half a second of each other
* adding to documentation, and/or adding tooltip or info somewhere in GUI.