### PR TITLE
Adds LORA popover on click and hover

### DIFF
--- a/src/wwwroot/js/genpage/gentab/loras.js
+++ b/src/wwwroot/js/genpage/gentab/loras.js
@@ -169,7 +169,7 @@ class LoraHelper {
                         if (popover.dataset.isClick == "true" && !isClick) {
                             return;
                         }
-                        popover.closeSelf();
+                        popover.remove();
                     }
                     let model = sdLoraBrowser.models[lora.name] ?? sdLoraBrowser.models[lora.name + ".safetensors"];
                     if (!model) {
@@ -198,30 +198,11 @@ class LoraHelper {
                     let left = Math.min(rect.left, window.innerWidth - popup.offsetWidth - 10);
                     popup.style.left = `${left}px`;
                     popup.classList.add('sui-popover-visible');
-                    popup.closeSelf = () => close(null);
-                    if (!isClick) {
-                        popup.style.pointerEvents = 'none';
-                    }
-                    let close = (e) => {
-                        if (isClick && e && e.target && popup.contains(e.target)) {
-                            return;
-                        }
-                        popup.remove();
-                        if (isClick) {
-                            document.removeEventListener('click', close);
-                            document.removeEventListener('contextmenu', close);
-                            document.removeEventListener('keydown', closeKey);
-                        }
-                    };
-                    let closeKey = (e) => {
-                        if (e.key == 'Escape') {
-                            close(null);
-                        }
-                    };
                     if (isClick) {
-                        document.addEventListener('click', close);
-                        document.addEventListener('contextmenu', close);
-                        document.addEventListener('keydown', closeKey);
+                        uiImprover.sustainPopover = popup;
+                    }
+                    else {
+                        popup.style.pointerEvents = 'none';
                     }
                 };
                 let hoverTimer = null;
@@ -246,7 +227,7 @@ class LoraHelper {
                     clearTimer(hoverTimer);
                     let popup = document.querySelector(`.sui-popover-visible[data-lora-name="${lora.name}"]`);
                     if (popup && popup.dataset.isClick != "true") {
-                        popup.closeSelf();
+                        popup.remove();
                     }
                 });
                 div.appendChild(confinementInput);
@@ -368,7 +349,6 @@ class LoraHelper {
         this.rebuildParams();
         this.rebuildUI();
     }
-
 }
 
 loraHelper = new LoraHelper();

--- a/src/wwwroot/js/genpage/helpers/ui_improvements.js
+++ b/src/wwwroot/js/genpage/helpers/ui_improvements.js
@@ -258,6 +258,25 @@ class UIImprovementHandler {
         this.timeOfLastTextboxSelectTrack = 0;
         this.lastTextboxCursorPos = -1;
         this.videoControlDragging = null;
+        this.sustainPopover = null;
+        document.addEventListener('click', e => {
+            if (this.sustainPopover && !this.sustainPopover.contains(e.target)) {
+                this.sustainPopover.remove();
+                this.sustainPopover = null;
+            }
+        });
+        document.addEventListener('contextmenu', e => {
+            if (this.sustainPopover && !this.sustainPopover.contains(e.target)) {
+                this.sustainPopover.remove();
+                this.sustainPopover = null;
+            }
+        });
+        document.addEventListener('keydown', e => {
+            if (this.sustainPopover && e.key == 'Escape') {
+                this.sustainPopover.remove();
+                this.sustainPopover = null;
+            }
+        });
         document.addEventListener('mousemove', (e) => {
             if (this.videoControlDragging) {
                 this.videoControlDragging.drag(e);


### PR DESCRIPTION
Adds a popover showing LORA information, triggered on left-click.

https://github.com/user-attachments/assets/4ac46a4f-e943-4a76-b0c4-d7d948092cca

* triggered on left-click of the LORA name, not the weight or region
* if user clicks on LORA name that is at edge of browser, popover scoots over to not overrun viewable area
* auto-closes any other opened LORA popover on opening any others, or clicking outside the popover area, or pressing ESC

Limitations:
* popover width hard-coded to 480px, does not take into account user's current display choice

See #616