### PR TITLE
Don't apply VideoEndFrame to Video Extends after the initial video

### DIFF
--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGenerator.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGenerator.cs
@@ -1414,6 +1414,7 @@ public partial class WorkflowGenerator
         public double DefaultCFG = 7;
         public bool HadSpecialCond = false;
         public int ContextID = T2IParamInput.SectionID_Video;
+        public Image VideoEndFrame = null;
 
         public void PrepModelAndCond(WorkflowGenerator g)
         {
@@ -1434,7 +1435,7 @@ public partial class WorkflowGenerator
             {
                 VideoFPS ??= 24;
                 Frames ??= 97;
-                if (g.UserInput.TryGet(T2IParamTypes.VideoEndFrame, out Image videoEndFrame))
+                if (VideoEndFrame is not null)
                 {
                     throw new SwarmReadableErrorException("LTX-V end-frame is TODO");
                 }
@@ -1474,7 +1475,7 @@ public partial class WorkflowGenerator
             {
                 VideoFPS ??= 24;
                 Frames ??= 121;
-                if (g.UserInput.TryGet(T2IParamTypes.VideoEndFrame, out Image videoEndFrame))
+                if (VideoEndFrame is not null)
                 {
                     throw new SwarmReadableErrorException("Cosmos end-frame is TODO");
                 }
@@ -1601,9 +1602,9 @@ public partial class WorkflowGenerator
                     });
                     imageIn = [fromBatch, 0];
                 }
-                if (g.UserInput.TryGet(T2IParamTypes.VideoEndFrame, out Image videoEndFrame))
+                if (VideoEndFrame is not null)
                 {
-                    string endFrame = g.CreateLoadImageNode(videoEndFrame, "${videoendframe}", false);
+                    string endFrame = g.CreateLoadImageNode(VideoEndFrame, "${videoendframe}", false);
                     JArray endFrameNode = [endFrame, 0];
                     string scaled = g.CreateNode("ImageScale", new JObject()
                     {
@@ -1692,9 +1693,9 @@ public partial class WorkflowGenerator
                     ["image"] = encodeIn,
                     ["crop"] = "center"
                 });
-                if (g.UserInput.TryGet(T2IParamTypes.VideoEndFrame, out Image videoEndFrame))
+                if (VideoEndFrame is not null)
                 {
-                    string endFrame = g.CreateLoadImageNode(videoEndFrame, "${videoendframe}", false);
+                    string endFrame = g.CreateLoadImageNode(VideoEndFrame, "${videoendframe}", false);
                     JArray endFrameNode = [endFrame, 0];
                     string scaled = g.CreateNode("ImageScale", new JObject()
                     {

--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
@@ -1738,7 +1738,8 @@ public class WorkflowGeneratorSteps
                     AltLatent = altLatent,
                     BatchIndex = batchInd,
                     BatchLen = batchLen,
-                    ContextID = T2IParamInput.SectionID_Video
+                    ContextID = T2IParamInput.SectionID_Video,
+                    VideoEndFrame = g.UserInput.Get(T2IParamTypes.VideoEndFrame, null)
                 };
                 g.CreateImageToVideo(genInfo);
                 videoFps = genInfo.VideoFPS;


### PR DESCRIPTION
Right now, if you specify a VideoEndFrame, that end frame will be applied both to the initial I2V and also to any <extend> prompts, so all the extends will be loops with same start and end frame. (There's no UI to specify more than one end frame).

(No bug, could add one if desired, only brief discussion in https://discord.com/channels/1243166023859961988/1243185862234210389/1444908753798561984)

This change removes the VideoEndFrame from the <extend> gens, only applying it to the initial I2V gen. This seems like a more common use case - providing one keyframe early on to try to keep the video on track - than looping video.

Tested Wan 2.2/2,1 flows with extends and with/without end frame, example output:
[ExtendWithEndFrame.json](https://github.com/user-attachments/files/23920941/ExtendWithEndFrame.json)


I suppose in theory a user could also have done the initial gen in T2V, added an extend, and provided a VideoEndFrame that would only apply to the extend. That seems like a pretty strange use case so I haven't done anything to treat extends of T2V differently than I2V.


