### PR TITLE
UI Support for the SeedVariance node

### DIFF
--- a/src/BuiltinExtensions/ComfyUIBackend/ComfyUIBackendExtension.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/ComfyUIBackendExtension.cs
@@ -68,7 +68,8 @@ public class ComfyUIBackendExtension : Extension
         ["TeaCache"] = "teacache",
         ["TeaCacheForVidGen"] = "teacache",
         ["TeaCacheForImgGen"] = "teacache_oldvers",
-        ["OverrideCLIPDevice"] = "set_clip_device"
+        ["OverrideCLIPDevice"] = "set_clip_device",
+        ["SeedVarianceEnhancer"] = "seed_variance_enhancer"
     };
 
     /// <inheritdoc/>
@@ -616,7 +617,9 @@ public class ComfyUIBackendExtension : Extension
 
     public static T2IRegisteredParam<bool> AITemplateParam, DebugRegionalPrompting, ShiftedLatentAverageInit, UseCfgZeroStar, UseTCFG;
 
-    public static T2IRegisteredParam<double> IPAdapterWeight, IPAdapterStart, IPAdapterEnd, SelfAttentionGuidanceScale, SelfAttentionGuidanceSigmaBlur, PerturbedAttentionGuidanceScale, StyleModelMergeStrength, StyleModelApplyStart, StyleModelMultiplyStrength, RescaleCFGMultiplier, TeaCacheThreshold, TeaCacheStart, NunchakuCacheThreshold, EasyCacheThreshold, EasyCacheStart, EasyCacheEnd, RenormCFG;
+    public static T2IRegisteredParam<double> IPAdapterWeight, IPAdapterStart, IPAdapterEnd, SelfAttentionGuidanceScale, SelfAttentionGuidanceSigmaBlur, PerturbedAttentionGuidanceScale, StyleModelMergeStrength, StyleModelApplyStart, StyleModelMultiplyStrength, RescaleCFGMultiplier, TeaCacheThreshold, TeaCacheStart, NunchakuCacheThreshold, EasyCacheThreshold, EasyCacheStart, EasyCacheEnd, RenormCFG, SeedVarianceStrength, SeedVarianceRandomize, SeedVarianceSwitchover;
+
+    public static T2IRegisteredParam<long> SeedVarianceSeed;
 
     public static T2IRegisteredParam<int> RefinerHyperTile, VideoFrameInterpolationMultiplier;
 
@@ -790,6 +793,18 @@ public class ComfyUIBackendExtension : Extension
             ));
         NunchakuCacheThreshold = T2IParamTypes.Register<double>(new("Nunchaku Cache Threshold", "What threshold to use with Nunchaku block caching.\nThis makes Nunchaku gens faster at the cost of quality.\nOnly applicable to Nunchaku models.\nGenerally 0 to 0.2 is the reasonable range, above that you can start noticing quality drop.",
             "0", IgnoreIf: "0", Min: 0, Max: 1, Step: 0.01, FeatureFlag: "nunchaku", Group: T2IParamTypes.GroupAdvancedSampling, IsAdvanced: true, ViewType: ParamViewType.SLIDER, OrderPriority: 16
+            ));
+        SeedVarianceStrength = T2IParamTypes.Register<double>(new("Seed Variance Strength", "Adds noise to conditioning embeddings to improve seed variance on models with low natural variance (like Z-Image Turbo).\nHigher values = more variance. Recommended range: 15-30.",
+            "20", Min: 0, Max: 100, Step: 1, ViewMax: 50, Toggleable: true, FeatureFlag: "seed_variance_enhancer", Group: T2IParamTypes.GroupAdvancedSampling, IsAdvanced: true, ViewType: ParamViewType.SLIDER, OrderPriority: 17
+            ));
+        SeedVarianceRandomize = T2IParamTypes.Register<double>(new("Seed Variance Randomize %", "Percentage of embedding values to add noise to.\nLower values preserve more of the original embedding, which can help maintain anatomy.\nRecommended: 20-30% if experiencing anatomy issues.",
+            "50", IgnoreIf: "50", Min: 0, Max: 100, Step: 5, FeatureFlag: "seed_variance_enhancer", Group: T2IParamTypes.GroupAdvancedSampling, IsAdvanced: true, ViewType: ParamViewType.SLIDER, OrderPriority: 17.2, DependNonDefault: SeedVarianceStrength.Type.ID
+            ));
+        SeedVarianceSwitchover = T2IParamTypes.Register<double>(new("Seed Variance Switchover %", "At what percentage of steps to switch from noisy to original embeddings.\nLower values mean noise only affects early composition steps.\nRecommended: 10-15% if experiencing anatomy issues.",
+            "20", IgnoreIf: "20", Min: 0, Max: 100, Step: 5, FeatureFlag: "seed_variance_enhancer", Group: T2IParamTypes.GroupAdvancedSampling, IsAdvanced: true, ViewType: ParamViewType.SLIDER, OrderPriority: 17.4, DependNonDefault: SeedVarianceStrength.Type.ID
+            ));
+        SeedVarianceSeed = T2IParamTypes.Register<long>(new("Seed Variance Seed", "Seed for the variance noise generation. Set to -1 to randomize.",
+            "-1", Min: -1, Max: long.MaxValue, ViewType: ParamViewType.SEED, FeatureFlag: "seed_variance_enhancer", Group: T2IParamTypes.GroupAdvancedSampling, IsAdvanced: true, OrderPriority: 17.6, DependNonDefault: SeedVarianceStrength.Type.ID
             ));
         SetClipDevice = T2IParamTypes.Register<string>(new("Set CLIP Device", "Override the hardware device that text encoders run on.",
             "cpu", FeatureFlag: "set_clip_device", Group: T2IParamTypes.GroupAdvancedModelAddons, IsAdvanced: true, Toggleable: true, GetValues: (_) => SetClipDevices, OrderPriority: 70

--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
@@ -1151,6 +1151,34 @@ public class WorkflowGeneratorSteps
             }
         }, -6);
         #endregion
+        #region Seed Variance Enhancer
+        AddStep(g =>
+        {
+            if (g.Features.Contains("seed_variance_enhancer") && g.UserInput.TryGet(ComfyUIBackendExtension.SeedVarianceStrength, out double strength))
+            {
+                long seed = g.UserInput.Get(ComfyUIBackendExtension.SeedVarianceSeed, -1L);
+                if (seed == -1)
+                {
+                    seed = Random.Shared.NextInt64(0, long.MaxValue);
+                }
+                double randomizePercent = g.UserInput.Get(ComfyUIBackendExtension.SeedVarianceRandomize, 50.0);
+                double switchoverPercent = g.UserInput.Get(ComfyUIBackendExtension.SeedVarianceSwitchover, 20.0);
+                string sveNode = g.CreateNode("SeedVarianceEnhancer", new JObject()
+                {
+                    ["conditioning"] = g.FinalPrompt,
+                    ["randomize_percent"] = randomizePercent,
+                    ["strength"] = strength,
+                    ["noise_insert"] = "noise on beginning steps",
+                    ["steps_switchover_percent"] = switchoverPercent,
+                    ["seed"] = seed,
+                    ["mask_starts_at"] = "beginning",
+                    ["mask_percent"] = 0.0,
+                    ["log_to_console"] = false
+                });
+                g.FinalPrompt = [sveNode, 0];
+            }
+        }, -5);
+        #endregion
         #region Sampler
         AddStep(g =>
         {


### PR DESCRIPTION
# Add SeedVarianceEnhancer Integration

Adds UI support for the https://github.com/ChangeTheConstants/SeedVarianceEnhancer ComfyUI custom node, which improves seed variance on models with low natural variance (like Z-Image Turbo).

## What it does

SeedVarianceEnhancer adds controlled noise to conditioning embeddings, resulting in more diverse outputs when changing seeds. This is particularly useful for turbo/distilled models that tend to produce very similar images across different seeds.

| Parameter                  | Description                                                                             | Default |
|----------------------------|-----------------------------------------------------------------------------------------|---------|
| Seed Variance Strength     | Noise scale added to embeddings. Higher = more variance.                                | 20      |
| Seed Variance Randomize %  | Percentage of embedding values to modify. Lower = more stable anatomy.                  | 50%     |
| Seed Variance Switchover % | When to stop using noisy embeddings (as % of steps). Lower = noise only on early steps. | 20%     |
| Seed Variance Seed         | Seed for noise generation. -1 = random.                                                 | -1      |

## Usage Notes
- Parameters appear in Advanced Sampling (requires "Advanced" toggle)
- Only visible when the SeedVarianceEnhancer node is installed in ComfyUI
- Applied to positive conditioning only
- For LoRAs with anatomy issues, try: Strength 10-15, Randomize 20-30%, Switchover 10-15%
