### PR TITLE
add star system for presets

### DIFF
--- a/src/wwwroot/css/genpage.css
+++ b/src/wwwroot/css/genpage.css
@@ -492,6 +492,9 @@ body {
 .model-starred img {
     box-shadow: 0 0 3px 1px color-mix(in srgb, var(--star) 50%, transparent);
 }
+.preset-block-starred img {
+    box-shadow: 0 0 3px 1px color-mix(in srgb, var(--star) 50%, transparent);
+}
 .sui_popover_model {
     white-space: normal;
 }

--- a/src/wwwroot/js/genpage/main.js
+++ b/src/wwwroot/js/genpage/main.js
@@ -328,6 +328,7 @@ function loadUserData(callback) {
     genericRequest('GetMyUserData', {}, data => {
         permissions.updateFrom(data.permissions);
         starredModels = data.starred_models;
+        starredPresets = Array.isArray(data.starred_presets) ? data.starred_presets : [];
         autoCompletionsList = {};
         if (data.autocompletions) {
             let allSet = [];


### PR DESCRIPTION
Implements #700, following the existing logic and UI patterns of the model star feature to ensure consistency.

BTW, I noticed that the current model star feature does not preserve the starred status after a model is renamed. In this PR, the starred status is preserved when a preset is renamed.

I did not modify the model-related behavior to keep this PR focused, but I would be happy to submit another one if needed.

Has been manually tested on Linux.
