### PR TITLE
Enlarge Plus Sign Gen Button

### DIFF
--- a/src/wwwroot/css/genpage.css
+++ b/src/wwwroot/css/genpage.css
@@ -970,15 +970,13 @@ body {
     top: 0;
 }
 .alt-text-add-button {
-    display: inline-flex;
     position: relative;
-    align-items: center;
-    justify-content: center;
     top: 2px;
     width: 29px;
     height: 29px;
     left: -5px;
-    padding: 0 !important;
+    padding-top: 2px;
+    padding-left: 9px !important;
     border-radius: 1rem !important;
 }
 .small-window .alt-text-add-button {


### PR DESCRIPTION
Edited some of the `genpage.css` code to make the plus sign button to the left of the prompt box look bigger and more noticeable. Added margin-right to the textbox itself to ensure it doesn't go behind the Generate Button.

Before & After attached.
Before:
<img width="1082" height="120" alt="image" src="https://github.com/user-attachments/assets/1c976ee5-d173-4a98-ae8f-d61dc668d914" />
After:
<img width="1089" height="135" alt="image" src="https://github.com/user-attachments/assets/d1efe2fc-8b0c-4dd3-a828-f8a35cd5323e" />