### PR TITLE
Fixes zoom in shows metadata on widescreen images

### DIFF
--- a/src/wwwroot/js/genpage/gentab/currentimagehandler.js
+++ b/src/wwwroot/js/genpage/gentab/currentimagehandler.js
@@ -170,6 +170,7 @@ class ImageFullViewHelper {
         let container = this.getImgOrContainer();
         let origHeight = this.getHeightPercent();
         let zoom = Math.pow(this.zoomRate, -e.deltaY / 100);
+        let isZoomingOut = zoom < 1;
         let width = img.naturalWidth ?? img.videoWidth;
         let height = img.naturalHeight ?? img.videoHeight;
         let maxHeight = Math.sqrt(width * height) * 2;
@@ -183,7 +184,7 @@ class ImageFullViewHelper {
         if (newHeight > 100.1) {
             this.toggleMetadataVisibility(false);
         }
-        else if (newHeight < 100.1) {
+        else if (isZoomingOut) {
             this.toggleMetadataVisibility(true);
         }
         container.style.cursor = 'grab';


### PR DESCRIPTION
Currently if you open a widescreen image in fullscreen modal, zooming in will display the metadata and zoom _out_ the image. User must then zoom in again to get past the 100% threshold to hide the metadata.

This fix works to only show the metadata when zooming OUT and image is < 1.