### PR TITLE
Adds counter to fullscreen image viewer

### DIFF
--- a/src/Pages/_Generate/GenerateTab.cshtml
+++ b/src/Pages/_Generate/GenerateTab.cshtml
@@ -192,8 +192,8 @@
         </div>
         <div class="modal modal-fullscreen imageview_popup_modal_background" id="image_fullview_modal">
             <div id="image_fullview_modal_content" style="width:fit-content;margin:auto;min-width:70vw;"></div>
-            <div id="image_fullview_modal_close">
-                <span id="image_fullview_modal_counter"></span>
+            <div class="image_fullview_modal_close">
+                <span id="image_fullview_modal_counter" class="image_fullview_modal_counter"></span>
                 <span class="text_button translate" onclick="imageFullView.close()">[Close]</span><br>
             </div>
         </div>

--- a/src/wwwroot/css/genpage.css
+++ b/src/wwwroot/css/genpage.css
@@ -738,18 +738,17 @@ body {
     font-family: var(--font-monospace);
     background-color: rgb(50, 50, 50, 0.7);
 }
-#image_fullview_modal_close {
+.image_fullview_modal_close {
     position: fixed;
     top: 1rem;
     right: 10%;
     width: 0;
     height: 0;
-    white-space:nowrap;
+    white-space: nowrap;
 }
-#image_fullview_modal_counter {
+.image_fullview_modal_counter {
     background-color: color-mix(in srgb, var(--button-background) 50%, transparent);
     color: var(--text);
-    cursor: default;
 }
 .imageview_modal_imagewrap {
     height: calc(100vh - 7rem);

--- a/src/wwwroot/js/genpage/gentab/currentimagehandler.js
+++ b/src/wwwroot/js/genpage/gentab/currentimagehandler.js
@@ -325,7 +325,7 @@ class ImageFullViewHelper {
     updateCounter() {
         let counterElem = getRequiredElementById('image_fullview_modal_counter');
         if (!this.currentSrc) {
-            counterElem.textContent = `1/${items.length} `;
+            counterElem.textContent = ``;
             return;
         }
         let items = [];
@@ -333,14 +333,16 @@ class ImageFullViewHelper {
         if (this.currentBatchId == 'history' && lastHistoryImageDiv && lastHistoryImageDiv.parentElement) {
             items = [...lastHistoryImageDiv.parentElement.children].filter(div => div.classList.contains('image-block'));
             index = items.findIndex(div => div == lastHistoryImageDiv);
-        } else {
+        }
+        else {
             let currentImageBatchDiv = getRequiredElementById('current_image_batch');
             items = [...currentImageBatchDiv.getElementsByClassName('image-block')].filter(block => !block.classList.contains('image-block-placeholder'));
             index = items.findIndex(block => block.dataset.src == this.currentSrc);
         }
         if (index != -1 && items.length > 0) {
             counterElem.textContent = `${index + 1}/${items.length} `;
-        } else {
+        }
+        else {
             counterElem.textContent = `1/${items.length} `;
         }
     }


### PR DESCRIPTION
Adds a simple counter to the fullscreen image viewer.

* only updates on image change (left/right/delete)
* if generating images the position might remain the same but total will increase
* placed inside `#image_fullview_modal_close` for easier grouping, but the counter does not inherit cursor/text-decoration

https://github.com/user-attachments/assets/67f67a12-71ad-4713-aa05-ea29ea146aa0

