### PR TITLE
Adds Base2Edit extension

### DIFF
--- a/launchtools/extension_list.fds
+++ b/launchtools/extension_list.fds
@@ -207,6 +207,15 @@ SeedVR2Upscaler:
     - parameters
     - nodes
 
+Base2Edit:
+    author: Juan Treminio
+    description: Edit an image in the refiner stage, allowing you to generate and edit in a single generation.
+    url: https://github.com/rlerdorf/SwarmUI-SeedVR2Upscaler
+    license: MIT
+    tags:
+    - parameters
+    - nodes
+
 WhatTheDuck:
     author: Juan Treminio
     description: Adds potentially-breaking power tools for obscure special cases. Most users should not install this.


### PR DESCRIPTION
Allows editing an image in the refiner stage. Works with native image prompt features like multiple images. The base image is considered the "first" image.

Example prompt:

```
<base>1girl, looking at viewer, smiling
<refiner>Reskin this into a realistic photograph
```

User should set refiner control to 1 for maximum effectiveness.

<img width="770" height="218" alt="CleanShot 2026-01-17 at 21 27 26@2x" src="https://github.com/user-attachments/assets/9f9de890-3027-434b-92fe-6aa7b031d80a" />
