### PR TITLE
Make LoRA trigger phrases selectable. 

### DIFF
--- a/src/wwwroot/css/genpage.css
+++ b/src/wwwroot/css/genpage.css
@@ -1708,3 +1708,38 @@ body {
     height: 1lh;
     padding-top: 0 !important;
 }
+
+.trigger-phrase-item {
+    display: inline-block;
+    margin-right: 0.3rem;
+    padding: 0.15rem 0.35rem;
+    border-radius: 0.25rem;
+    cursor: pointer;
+}
+.trigger-phrase-item:hover {
+    background: var(--light-border);
+}
+.trigger-phrase-selected {
+    background: var(--accent-primary-color, #3b82f6);
+    color: white;
+}
+.trigger-phrase-copy-all-button {
+    margin-left: 0.4rem;
+    vertical-align: middle;
+}
+
+.trigger-phrases-container {
+    display: block;
+    margin-top: 0.25rem;
+    line-height: 1.4;
+}
+.trigger-phrases-container .trigger-phrase-copy-button {
+    margin-left: 0.15rem;
+}
+
+.trigger-phrase-sep {
+    display: inline-block;
+    margin-right: 0.1rem;
+    margin-left: 0.1rem;
+    color: var(--muted-text-color, #666);
+}

--- a/src/wwwroot/js/genpage/gentab/models.js
+++ b/src/wwwroot/js/genpage/gentab/models.js
@@ -120,6 +120,50 @@ class ModelsHelpers {
 /** Collection of helper functions and data related to models, just an instance of {@link ModelsHelpers}. */
 let modelsHelpers = new ModelsHelpers();
 
+// Toggle selection for a trigger phrase span (click to select/deselect)
+function toggleTriggerPhraseSelected(elem) {
+    try {
+        if (!elem) return;
+        if (elem.classList.contains('trigger-phrase-item')) {
+            elem.classList.toggle('trigger-phrase-selected');
+        }
+    }
+    catch (e) {
+        console.error('toggleTriggerPhraseSelected error', e);
+    }
+}
+
+// Copy selected trigger phrases within the same container. If none selected, copies all.
+function copySelectedTriggerPhrases(buttonElem) {
+    try {
+        let container = buttonElem && buttonElem.closest ? buttonElem.closest('.trigger-phrases-container') : null;
+        if (!container) return;
+        let selected = Array.from(container.querySelectorAll('.trigger-phrase-item.trigger-phrase-selected'));
+        if (selected.length === 0) {
+            selected = Array.from(container.querySelectorAll('.trigger-phrase-item'));
+        }
+        let phrases = selected.map(el => el.innerText.trim()).filter(s => s.length > 0);
+        let text = phrases.join(', ');
+        if (getUserSetting('ui.copytriggerphrasewithtrailingcomma', false) && text !== '' && !text.endsWith(',')) {
+            text += ', ';
+        }
+        if (text.length > 0) {
+            copyText(text);
+            doNoticePopover('Copied!', 'notice-pop-green');
+            // Clear selection after copying
+            try {
+                selected.forEach(el => el.classList.remove('trigger-phrase-selected'));
+            }
+            catch (e) {
+                console.error('Error clearing trigger phrase selections', e);
+            }
+        }
+    }
+    catch (e) {
+        console.error('copySelectedTriggerPhrases error', e);
+    }
+}
+
 //////////// TODO: Merge all the below into the class above (or multiple separate classes)
 
 let models = {};
@@ -590,16 +634,24 @@ class ModelBrowserWrapper {
         }
         let safePhrase = escapeHtmlNoBr(escapeJsString(phrase));
         let safeCopyPhrase = escapeHtmlNoBr(escapeJsString(copyPhrase));
-        return `${safePhrase}<button title="Click to copy" class="basic-button trigger-phrase-copy-button" onclick="copyText('${safeCopyPhrase}');doNoticePopover('Copied!', 'notice-pop-green');">&#x29C9;</button>`;
+        // Render phrase as a selectable span only (individual copy button removed).
+        // Selection state is toggled by clicking the span.
+        return `<span class="trigger-phrase-item" onclick="toggleTriggerPhraseSelected(this)">${safePhrase}</span>`;
     }
 
     formatTriggerPhrases(val) {
-        let phrases = val.split(';').map(phrase => phrase.trim()).filter(phrase => phrase.length > 0);
+        // Support both semicolon and comma separated lists. Split on either and trim.
+        let phrases = val.split(/[;,]/).map(phrase => phrase.trim()).filter(phrase => phrase.length > 0);
         if (phrases.length > 128) {
             phrases = phrases.slice(0, 128);
         }
-        return phrases.map(phrase => this.createCopyableTriggerPhrase(phrase)).join('');
+        // Join phrases with a visible comma separator so each value is individually selectable.
+        let inner = phrases.map(phrase => this.createCopyableTriggerPhrase(phrase)).join('<span class="trigger-phrase-sep">, </span>');
+        return `<div class="trigger-phrases-container">${inner}<button title="Copy selected phrases" class="basic-button trigger-phrase-copy-all-button" onclick="copySelectedTriggerPhrases(this)">&#x2398;</button></div>`;
     }
+
+    // Toggle selection state for a trigger phrase element
+    
 
     describeModel(model) {
         let description = '';


### PR DESCRIPTION
This makes each word in the coma separated lists selectable  individually. Once you have selected each word you would like to copy you can click the button at the end of the list and it will copy only those selected words/phrases to the clipboard. If you want to copy the entire thing just click the copy button and it will copy everything.

I do a lot of jank stuff so maybe someone can clean this and make it nicer? 