### PR TITLE
Enforce image order when generating new

### DIFF
--- a/src/wwwroot/js/genpage/helpers/generatehandler.js
+++ b/src/wwwroot/js/genpage/helpers/generatehandler.js
@@ -182,9 +182,7 @@ class GenerateHandler {
                 let imgElem = div.querySelector('img');
                 let spinner = div.querySelector('.loading-spinner-parent');
                 let progress_bars = div.querySelector('.image-preview-progress-wrapper');
-                let isPreviewSwapToCompleted = imgElem.dataset.previewGrow
-                    || progress_bars
-                    || spinner;
+                let isPreviewSwapToCompleted = imgElem.dataset.previewGrow || progress_bars || spinner;
                 this.setImageFor(imgHolder, data.image);
                 if (spinner) {
                     spinner.remove();


### PR DESCRIPTION
This PR allows considering the first image in a given Generate as the "final" product. Any intermediate snapshots of the image before the final SwarmSaveImage node are considered intermediaries. The immediate use-case is allowing a (non-native) `base image -> edit image` workflow to save the pre-edit image and display it before the final edited image, in the batch container UI.

What happens now, where the version on the right "this is the edited image" is attached to the initial stream, and the "this is the base image" is cut mid-workflow.

<img width="896" height="1382" alt="CleanShot 2026-01-28 at 20 22 28@2x" src="https://github.com/user-attachments/assets/9c100c57-8234-443f-9f9a-ebedd34ff347" />

With this PR, the initial stream is considered the primary and is moved to the top of the list once all other images in that workflow have been saved:

<img width="934" height="1404" alt="CleanShot 2026-01-28 at 20 20 52@2x" src="https://github.com/user-attachments/assets/55208d3b-d68f-4238-818d-daaf625918e8" />

An example workflow that showcases multiple images saved in a single workflow would look like:

<img width="2598" height="1556" alt="CleanShot 2026-01-28 at 20 25 31@2x" src="https://github.com/user-attachments/assets/5b4dd18a-80e6-413f-9405-81b56f126caf" />

To minimize diff, this PR only affects image-based workflows. Video and other media will continue behaving as-is.