### PR TITLE
Add optional PythonPath for ComfyUI self-start backends

### DIFF
--- a/src/BuiltinExtensions/ComfyUIBackend/README.md
+++ b/src/BuiltinExtensions/ComfyUIBackend/README.md
@@ -17,6 +17,7 @@ You can also view the ComfyUI node graph and work with custom workflows directly
 
 - First: Have a valid ComfyUI install. The SwarmUI installer automatically provides you one (if not disabled) as `dlbackend/comfy/ComfyUI/main.py`.
 - Go to `Server` -> `Backends`, and click `ComfyUI Self-Starting`, and fill in the `StartScript` path as above. Other values can be left default or configured to your preference.
+    - Optional: set `PythonPath` if your desired python/venv is not in ComfyUI's default location. This can point to either a python executable or a venv root folder.
 - Save the backend, and it should just work.
 
 ### Installation (API)


### PR DESCRIPTION
## Summary
- add an optional `PythonPath` setting to `ComfyUI Self-Starting` backends
- allow this setting to point to either a python executable or a venv root directory
- plumb the override through launch and dependency/lib detection paths
- document the new setting in the Comfy backend README

## Why
Some installs keep a valid venv outside the default `ComfyUI/venv` path. This makes self-start use that environment without requiring folder junctions/symlinks.

## Testing
- static call-site check completed
- full build was not run in this environment (`dotnet` CLI not available)