### PR TITLE
Port LoRA trigger tag selection UI from SwarmUI_2026-02-10

### DIFF
--- a/src/wwwroot/css/genpage.css
+++ b/src/wwwroot/css/genpage.css
@@ -1707,6 +1707,32 @@ body {
     font-size: 90%;
     height: 1lh;
     padding-top: 0 !important;
+    margin-left: 0.2rem;
+}
+.trigger-phrase-entry {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: wrap;
+    row-gap: 0.2rem;
+}
+.trigger-phrase-tag {
+    display: inline-block;
+    border: 1px solid var(--light-border);
+    border-radius: 0.3rem;
+    padding: 0 0.25rem;
+    cursor: pointer;
+    user-select: none;
+    line-height: 1.3;
+}
+.trigger-phrase-tag:hover {
+    background-color: var(--emphasis);
+}
+.trigger-phrase-tag-selected {
+    border-color: var(--box-selected-border-stronger);
+    background-color: color-mix(in srgb, var(--box-selected-background) 80%, transparent);
+}
+.trigger-phrase-separator {
+    opacity: 0.8;
 }
 .view_raw_header_modal_content {
     max-height: 70vh;


### PR DESCRIPTION
## Summary
- ports LoRA trigger phrase tag selection UI from SwarmUI_2026-02-10 into swarm-clean
- supports selecting individual trigger tags and copying selected tags
- default behavior of copy button is preserved so no selection results in entire block being copied.
- keeps trailing-comma copy setting behavior and clears selection after copy
