### PR TITLE
Adds DownloaderHelper extension

### DIFF
--- a/launchtools/extension_list.fds
+++ b/launchtools/extension_list.fds
@@ -235,3 +235,11 @@ WhatTheDuck:
     tags:
     - tools
     - conflicts
+
+DownloaderHelper:
+    author: Juan Treminio
+    description: Allows sending model download URLs directly to the SwarmUI Model Downloader page from a "Send to SwarmUI" right-click menu item in Chrome Web Browser. See README for instructions on installing the Chrome extension.
+    url: https://github.com/jtreminio/SwarmUI-DownloaderHelper
+    license: MIT
+    tags:
+    - tools


### PR DESCRIPTION
https://github.com/jtreminio/SwarmUI-DownloaderHelper

This is a two-part extension:

1) The SwarmUI extension that wraps around the Model Downloader page
    * allows setting model URL via GET param
    * allows changing that URL without a refresh of the page
2) The Chrome extension that adds a "Send to SwarmUI" item to the right-click menu
    * works on any page, send the page URL to the defined SwarmUI server URL
    * works on `<a>` links, sends the `href` value to the SwarmUI server URL
    * on first use, opens extension settings page to set the SwarmUI server URL
    * opens the SwarmUI Model Downloader page in a new minimal window, or a regular tab
    * reuses existing window or tab on subsequent clicks, without reloading the page

I am currently in the process of figuring out how to publish an extension to Chrome Extension Store so users don't have to install the Chrome extension from local folder.

https://github.com/user-attachments/assets/4934086b-aed8-48fa-b9cc-828624d7b26e

<img width="898" height="483" alt="screenshot-1" src="https://github.com/user-attachments/assets/0c9c65c0-9c02-4616-bf68-44e357de74fc" />

<img width="551" height="470" alt="screenshot-2" src="https://github.com/user-attachments/assets/6cdc9882-0a15-4b97-b6e3-28e6611a544a" />

<img width="716" height="397" alt="screenshot-3" src="https://github.com/user-attachments/assets/1a068830-27e9-43f4-a50c-33a456706577" />
