### PR TITLE
Disable pip cache for Docker

### DIFF
--- a/launchtools/StandardDockerfile.docker
+++ b/launchtools/StandardDockerfile.docker
@@ -9,6 +9,11 @@ RUN apt install -y git wget build-essential python3.11 python3.11-venv python3.1
 # Install dependencies for controlnet preprocessors
 RUN apt install -y libglib2.0-0 libgl1
 
+# Disable pip cache to avoid exceeding size limits
+RUN mkdir -p /etc && \
+    echo "[global]" > /etc/pip.conf && \
+    echo "no-cache-dir = true" >> /etc/pip.conf
+
 # Copy swarm's files into the docker container
 COPY . ./SwarmUI
 


### PR DESCRIPTION
This pull requests disables the pip cache inside the container, to avoid issues with large downloads exceeding limits. It also makes the container smaller in footprint.
Fixes https://github.com/mcmonkeyprojects/SwarmUI/issues/1303.