### PR TITLE
use default image dimensions for SAM2 image when no selection in editor

### DIFF
--- a/src/wwwroot/js/genpage/helpers/image_editor_tools.js
+++ b/src/wwwroot/js/genpage/helpers/image_editor_tools.js
@@ -1347,11 +1347,14 @@ class ImageEditorToolSam2Base extends ImageEditorTool {
 
     /** Returns the image data and coordinate offset for SAM2 requests, cropped to the selection if active. */
     getImageForSam() {
+        let width, height;
         if (!this.editor.hasSelection) {
-            return { image: this.editor.getFinalImageData(), offsetX: 0, offsetY: 0 };
+            width = Math.round(this.editor.realWidth);
+            height = Math.round(this.editor.realHeight);
+            return { image: this.editor.getFinalImageData(), offsetX: 0, offsetY: 0, width, height };
         }
-        let width = Math.round(this.editor.selectWidth);
-        let height = Math.round(this.editor.selectHeight);
+        width = Math.round(this.editor.selectWidth);
+        height = Math.round(this.editor.selectHeight);
         let image = this.editor.getImageWithBounds(this.editor.selectX, this.editor.selectY, width, height);
         return { image: image, offsetX: this.editor.selectX, offsetY: this.editor.selectY, width: width, height: height };
     }


### PR DESCRIPTION
This fixes a bug whereby the SAM2 mask is returned where `width` and `height` are `undefined` if the user has not created a selection with the 'Selection' tool.

This will used the default image dimensions from the editor.