### PR TITLE
Adds PostRenderTorched extension

### DIFF
--- a/launchtools/extension_list.fds
+++ b/launchtools/extension_list.fds
@@ -89,10 +89,11 @@ WildcardImporter:
     - tabs
     - ui
 
-PostRenderTorched:
-    author: Juan Treminio
-    description: Adds support for a variety of useful post-processing techniques - LUTs, film grain, vignette, blur, and more. Updated version of the original PostRender extension, uses Torch, up to 74% speedup compared to the original. *Warning*: You must uninstall the old PostRender extension first before installing this one!
+PostRender:
+    author: Juan Treminio, orig. HellerCommaA
+    description: Adds support for a variety of useful post-processing techniques - LUTs, film grain, vignette, blur, and more. Updated and replaced to a new repo March 2026.
     url: https://github.com/jtreminio/SwarmUI-PostRenderTorched
+    old_url: https://github.com/HellerCommaA/SwarmUI-PostRender
     license: MIT
     tags:
     - parameters


### PR DESCRIPTION
[Benchmark data available here](https://github.com/jtreminio/SwarmUI-PostRenderTorched). Up to 74% faster than original PostRender extension.

* includes a set of LUTs, and handy presets for Film Grain, Vignette, Depth Map Blur, Radial Blur
* combines all the separate features into one unified group
* bakes the (refactored) ComfyUI node into the extension itself
* no extra Python dependencies, so yay

![1830001-Young American woman, smiling, looking a-6](https://github.com/user-attachments/assets/8d31df61-1ece-4676-93ce-bc218df41c29)

I had a PR against the original PostRender repo but no response after over a week. Figure I might as well do it myself.