### PR TITLE
feat: add MiniMax Cloud LLM as a built-in backend provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Key feature targets not yet implemented:
 - Better mobile browser support
 - full detail "Current Model" display in UI, separate from the model selector (probably as a tab within the batch sidebar?)
 - LLM-assisted prompting (there's an extension for it, but LLM control should be natively supported)
+    - Built-in LLM backends include: Local LLaMA.cpp, Remote OpenAI API, and [MiniMax](https://platform.minimaxi.com) Cloud LLM (M2.7, M2.5, M2.5-highspeed)
 - convenient direct-distribution of Swarm as a program ([Tauri](https://tauri.app/), [Blazor Desktop](https://learn.microsoft.com/en-us/training/modules/build-blazor-hybrid/), or an Electron app?)
 
 # Donate

--- a/src/Backends/BackendHandler.cs
+++ b/src/Backends/BackendHandler.cs
@@ -108,7 +108,7 @@ public class BackendHandler
     }
 
     /// <summary>Registered core backend types.</summary>
-    public BackendType SwarmBackendType, AutoScalingBackendType, LlamaSharpBackendType, SimpleRemoteLLMBackendType;
+    public BackendType SwarmBackendType, AutoScalingBackendType, LlamaSharpBackendType, SimpleRemoteLLMBackendType, MiniMaxLLMBackendType;
 
     public BackendHandler()
     {
@@ -116,6 +116,7 @@ public class BackendHandler
         AutoScalingBackendType = RegisterBackendType<AutoScalingBackend>("autoscalingbackend", "Auto Scaling Backend", "(Advanced users only) Automatically launch other instances of SwarmUI to serve as dynamic additional backends.", true, false);
         LlamaSharpBackendType = RegisterBackendType<LlamaSharpLLMBackend>("localllama", "Local LLaMA.cpp GGUF Backend", "(EXPERIMENTAL) Same-process local LLaMA GGUF LLM support.", true, false);
         SimpleRemoteLLMBackendType = RegisterBackendType<SimpleRemoteLLMBackend>("simpleremotellm", "Remote LLM (OpenAI API)", "(EXPERIMENTAL) Support for any OpenAI API compatible LLM provider.", true, false);
+        MiniMaxLLMBackendType = RegisterBackendType<MiniMaxLLMBackend>("minimax_llm", "MiniMax Cloud LLM", "MiniMax Cloud API LLM provider, supporting MiniMax-M2.7, MiniMax-M2.5, and MiniMax-M2.5-highspeed models. Get an API key at https://platform.minimaxi.com", true, false);
         Program.ModelRefreshEvent += () =>
         {
             List<Task> waitFor = [];

--- a/src/Backends/MiniMaxLLMBackend.cs
+++ b/src/Backends/MiniMaxLLMBackend.cs
@@ -1,0 +1,252 @@
+using FreneticUtilities.FreneticDataSyntax;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using SwarmUI.Core;
+using SwarmUI.LLMs;
+using SwarmUI.Utils;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace SwarmUI.Backends;
+
+/// <summary>An LLM Backend powered by MiniMax Cloud API (OpenAI-compatible).</summary>
+public class MiniMaxLLMBackend : AbstractLLMBackend
+{
+    public class MiniMaxLLMBackendSettings : AutoConfiguration
+    {
+        [ConfigComment("Your MiniMax API key.\nGet one at https://platform.minimaxi.com")]
+        [ValueIsSecret]
+        public string ApiKey = "";
+
+        [ConfigComment("The MiniMax API base URL.\nDefault is 'https://api.minimax.io/v1'.")]
+        public string BaseUrl = "https://api.minimax.io/v1";
+
+        [ConfigComment("The model to use for generation.\nAvailable models: MiniMax-M2.7, MiniMax-M2.5, MiniMax-M2.5-highspeed")]
+        public string Model = "MiniMax-M2.7";
+
+        [ConfigComment("Sampling temperature for generation.\nValid range: 0.0 to 1.0. Lower values are more deterministic.")]
+        public double Temperature = 0.7;
+
+        [ConfigComment("Maximum number of tokens to generate.\nSet to 0 to use the model's default.")]
+        public int MaxTokens = 0;
+
+        [ConfigComment("Whether the backend is allowed to revert to an 'idle' state if the API is unresponsive.\nAn idle state is not an error, but cannot generate.")]
+        public bool AllowIdle = false;
+
+        [ConfigComment("Connection timeout in seconds when making API requests.")]
+        public int TimeoutSeconds = 120;
+    }
+
+    /// <summary>The settings for this backend.</summary>
+    public MiniMaxLLMBackendSettings Settings => SettingsRaw as MiniMaxLLMBackendSettings;
+
+    /// <summary>Shared HTTP client for API requests.</summary>
+    public HttpClient Client;
+
+    /// <inheritdoc/>
+    public override async Task Init()
+    {
+        if (string.IsNullOrWhiteSpace(Settings.ApiKey))
+        {
+            throw new InvalidOperationException("MiniMax API key is not configured. Please set your API key in the backend settings.");
+        }
+        Client = NetworkBackendUtils.MakeHttpClient(Settings.TimeoutSeconds / 60 + 1);
+        Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", Settings.ApiKey);
+        // Validate connection by listing models
+        try
+        {
+            HttpResponseMessage response = await Client.GetAsync($"{Settings.BaseUrl.TrimEnd('/')}/models");
+            if (!response.IsSuccessStatusCode)
+            {
+                string body = await response.Content.ReadAsStringAsync();
+                if (Settings.AllowIdle)
+                {
+                    Status = BackendStatus.IDLE;
+                    Logs.Warning($"MiniMax API returned {response.StatusCode} during init, entering idle state: {body}");
+                    return;
+                }
+                throw new InvalidOperationException($"MiniMax API returned {response.StatusCode}: {body}");
+            }
+            Logs.Info($"MiniMax LLM backend initialized successfully with model {Settings.Model}");
+            Status = BackendStatus.RUNNING;
+        }
+        catch (HttpRequestException ex)
+        {
+            if (Settings.AllowIdle)
+            {
+                Status = BackendStatus.IDLE;
+                Logs.Warning($"MiniMax API unreachable during init, entering idle state: {ex.Message}");
+                return;
+            }
+            throw;
+        }
+    }
+
+    /// <inheritdoc/>
+    public override async Task Shutdown()
+    {
+        NetworkBackendUtils.ClearOldHttpClient(Client);
+        Client = null;
+    }
+
+    /// <summary>Builds the messages array from the LLM input parameters.</summary>
+    private JArray BuildMessages(LLMParamInput userInput)
+    {
+        JArray messages = [];
+        if (userInput.ChatHistory is not null)
+        {
+            foreach (var message in userInput.ChatHistory.Messages)
+            {
+                string role = message.AuthorRole.ToString().ToLowerInvariant();
+                // Map LLamaSharp roles to OpenAI roles
+                if (role == "unknown")
+                {
+                    role = "user";
+                }
+                messages.Add(new JObject { ["role"] = role, ["content"] = message.Content });
+            }
+        }
+        if (!string.IsNullOrEmpty(userInput.UserMessage))
+        {
+            messages.Add(new JObject { ["role"] = "user", ["content"] = userInput.UserMessage });
+        }
+        return messages;
+    }
+
+    /// <summary>Builds the request body for a chat completion call.</summary>
+    private JObject BuildRequestBody(LLMParamInput userInput, bool stream)
+    {
+        string model = string.IsNullOrWhiteSpace(userInput.Model) ? Settings.Model : userInput.Model;
+        double temperature = Math.Clamp(Settings.Temperature, 0.0, 1.0);
+        JObject body = new()
+        {
+            ["model"] = model,
+            ["messages"] = BuildMessages(userInput),
+            ["temperature"] = temperature,
+            ["stream"] = stream
+        };
+        if (Settings.MaxTokens > 0)
+        {
+            body["max_tokens"] = Settings.MaxTokens;
+        }
+        return body;
+    }
+
+    /// <inheritdoc/>
+    public override async Task<string> Generate(LLMParamInput userInput)
+    {
+        if (Client is null)
+        {
+            throw new InvalidOperationException("MiniMax backend is not initialized.");
+        }
+        JObject requestBody = BuildRequestBody(userInput, false);
+        StringContent content = new(requestBody.ToString(Formatting.None), Encoding.UTF8, "application/json");
+        HttpResponseMessage response = await Client.PostAsync($"{Settings.BaseUrl.TrimEnd('/')}/chat/completions", content);
+        string responseText = await response.Content.ReadAsStringAsync();
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException($"MiniMax API error ({response.StatusCode}): {responseText}");
+        }
+        JObject result = JObject.Parse(responseText);
+        string text = result["choices"]?[0]?["message"]?["content"]?.ToString() ?? "";
+        // Strip thinking tags if present (MiniMax M2.5+ may include <think>...</think> blocks)
+        text = StripThinkingTags(text);
+        return text;
+    }
+
+    /// <inheritdoc/>
+    public override async Task GenerateLive(LLMParamInput userInput, string batchId, Action<JObject> takeOutput)
+    {
+        if (Client is null)
+        {
+            throw new InvalidOperationException("MiniMax backend is not initialized.");
+        }
+        JObject requestBody = BuildRequestBody(userInput, true);
+        HttpRequestMessage request = new(HttpMethod.Post, $"{Settings.BaseUrl.TrimEnd('/')}/chat/completions")
+        {
+            Content = new StringContent(requestBody.ToString(Formatting.None), Encoding.UTF8, "application/json")
+        };
+        HttpResponseMessage response = await Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+        if (!response.IsSuccessStatusCode)
+        {
+            string errorText = await response.Content.ReadAsStringAsync();
+            throw new InvalidOperationException($"MiniMax API error ({response.StatusCode}): {errorText}");
+        }
+        using Stream stream = await response.Content.ReadAsStreamAsync();
+        using StreamReader reader = new(stream, Encoding.UTF8);
+        StringBuilder fullContent = new();
+        while (!reader.EndOfStream)
+        {
+            string line = await reader.ReadLineAsync();
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+            if (!line.StartsWith("data: "))
+            {
+                continue;
+            }
+            string data = line["data: ".Length..];
+            if (data == "[DONE]")
+            {
+                break;
+            }
+            try
+            {
+                JObject chunk = JObject.Parse(data);
+                string delta = chunk["choices"]?[0]?["delta"]?["content"]?.ToString();
+                if (!string.IsNullOrEmpty(delta))
+                {
+                    fullContent.Append(delta);
+                    takeOutput(new JObject { ["chunk"] = delta });
+                }
+            }
+            catch (JsonReaderException)
+            {
+                // Skip malformed SSE chunks
+            }
+        }
+        string fullText = StripThinkingTags(fullContent.ToString());
+        // If thinking tags were stripped, re-emit the cleaned result
+        if (fullText != fullContent.ToString())
+        {
+            takeOutput(new JObject { ["result"] = fullText });
+        }
+    }
+
+    /// <summary>Strips <![CDATA[<think>...</think>]]> blocks from MiniMax model responses.</summary>
+    internal static string StripThinkingTags(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return text;
+        }
+        while (true)
+        {
+            int startIdx = text.IndexOf("<think>", StringComparison.OrdinalIgnoreCase);
+            if (startIdx < 0)
+            {
+                break;
+            }
+            int endIdx = text.IndexOf("</think>", startIdx, StringComparison.OrdinalIgnoreCase);
+            if (endIdx < 0)
+            {
+                // Incomplete think block, remove from start tag onwards
+                text = text[..startIdx];
+                break;
+            }
+            text = text[..startIdx] + text[(endIdx + "</think>".Length)..];
+        }
+        return text.TrimStart();
+    }
+
+    /// <inheritdoc/>
+    public override IEnumerable<string> SupportedFeatures => ["llm", "remote_llm"];
+
+    /// <inheritdoc/>
+    public override async Task<bool> FreeMemory(bool systemRam)
+    {
+        return false;
+    }
+}

--- a/tests/SwarmUI.Tests/MiniMaxLLMBackendIntegrationTests.cs
+++ b/tests/SwarmUI.Tests/MiniMaxLLMBackendIntegrationTests.cs
@@ -1,0 +1,85 @@
+using NUnit.Framework;
+using SwarmUI.Backends;
+using SwarmUI.LLMs;
+
+namespace SwarmUI.Tests;
+
+/// <summary>Integration tests for MiniMax LLM backend. Requires MINIMAX_API_KEY environment variable.</summary>
+[TestFixture]
+[Category("Integration")]
+public class MiniMaxLLMBackendIntegrationTests
+{
+    private MiniMaxLLMBackend _backend;
+    private string _apiKey;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _apiKey = Environment.GetEnvironmentVariable("MINIMAX_API_KEY") ?? "";
+        if (string.IsNullOrEmpty(_apiKey))
+        {
+            Assert.Ignore("MINIMAX_API_KEY environment variable not set, skipping integration tests.");
+        }
+        _backend = new MiniMaxLLMBackend();
+        _backend.SettingsRaw = new MiniMaxLLMBackend.MiniMaxLLMBackendSettings
+        {
+            ApiKey = _apiKey,
+            BaseUrl = "https://api.minimax.io/v1",
+            Model = "MiniMax-M2.5-highspeed",
+            Temperature = 0.1,
+            MaxTokens = 100
+        };
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        if (_backend is not null)
+        {
+            await _backend.Shutdown();
+        }
+    }
+
+    [Test]
+    public async Task Init_WithValidApiKey_Succeeds()
+    {
+        await _backend.Init();
+        Assert.That(_backend.Status, Is.EqualTo(BackendStatus.RUNNING));
+    }
+
+    [Test]
+    public async Task Generate_SimplePrompt_ReturnsNonEmptyResponse()
+    {
+        await _backend.Init();
+        var input = new LLMParamInput
+        {
+            UserMessage = "Reply with exactly: Hello MiniMax",
+            Model = "MiniMax-M2.5-highspeed"
+        };
+        string result = await _backend.Generate(input);
+        Assert.That(result, Is.Not.Empty);
+        Assert.That(result.ToLowerInvariant(), Does.Contain("hello"));
+    }
+
+    [Test]
+    public async Task GenerateLive_SimplePrompt_StreamsChunks()
+    {
+        await _backend.Init();
+        var input = new LLMParamInput
+        {
+            UserMessage = "Count from 1 to 5, separated by commas.",
+            Model = "MiniMax-M2.5-highspeed"
+        };
+        var chunks = new List<string>();
+        await _backend.GenerateLive(input, "test-batch", output =>
+        {
+            if (output.TryGetValue("chunk", out var chunk))
+            {
+                chunks.Add(chunk.ToString());
+            }
+        });
+        Assert.That(chunks, Has.Count.GreaterThan(0), "Expected at least one streamed chunk");
+        string combined = string.Join("", chunks);
+        Assert.That(combined, Is.Not.Empty);
+    }
+}

--- a/tests/SwarmUI.Tests/MiniMaxLLMBackendTests.cs
+++ b/tests/SwarmUI.Tests/MiniMaxLLMBackendTests.cs
@@ -1,0 +1,138 @@
+using NUnit.Framework;
+using SwarmUI.Backends;
+
+namespace SwarmUI.Tests;
+
+/// <summary>Unit tests for the MiniMax LLM backend.</summary>
+[TestFixture]
+public class MiniMaxLLMBackendTests
+{
+    [Test]
+    public void StripThinkingTags_NoTags_ReturnsUnchanged()
+    {
+        string input = "Hello, world!";
+        string result = MiniMaxLLMBackend.StripThinkingTags(input);
+        Assert.That(result, Is.EqualTo("Hello, world!"));
+    }
+
+    [Test]
+    public void StripThinkingTags_WithThinkBlock_StripsIt()
+    {
+        string input = "<think>internal reasoning here</think>The actual answer is 42.";
+        string result = MiniMaxLLMBackend.StripThinkingTags(input);
+        Assert.That(result, Is.EqualTo("The actual answer is 42."));
+    }
+
+    [Test]
+    public void StripThinkingTags_WithMultipleThinkBlocks_StripsAll()
+    {
+        string input = "<think>first thought</think>Part 1 <think>second thought</think>Part 2";
+        string result = MiniMaxLLMBackend.StripThinkingTags(input);
+        Assert.That(result, Is.EqualTo("Part 1 Part 2"));
+    }
+
+    [Test]
+    public void StripThinkingTags_IncompleteThinkBlock_StripsFromTag()
+    {
+        string input = "The answer is 42.<think>still thinking...";
+        string result = MiniMaxLLMBackend.StripThinkingTags(input);
+        Assert.That(result, Is.EqualTo("The answer is 42."));
+    }
+
+    [Test]
+    public void StripThinkingTags_EmptyString_ReturnsEmpty()
+    {
+        Assert.That(MiniMaxLLMBackend.StripThinkingTags(""), Is.EqualTo(""));
+    }
+
+    [Test]
+    public void StripThinkingTags_NullString_ReturnsNull()
+    {
+        Assert.That(MiniMaxLLMBackend.StripThinkingTags(null), Is.Null);
+    }
+
+    [Test]
+    public void StripThinkingTags_CaseInsensitive_Strips()
+    {
+        string input = "<THINK>reasoning</THINK>Result here";
+        string result = MiniMaxLLMBackend.StripThinkingTags(input);
+        Assert.That(result, Is.EqualTo("Result here"));
+    }
+
+    [Test]
+    public void StripThinkingTags_MultilineThinkBlock_Strips()
+    {
+        string input = "<think>\nLine 1 of thought\nLine 2 of thought\n</think>Final answer.";
+        string result = MiniMaxLLMBackend.StripThinkingTags(input);
+        Assert.That(result, Is.EqualTo("Final answer."));
+    }
+
+    [Test]
+    public void Settings_DefaultValues_AreCorrect()
+    {
+        var settings = new MiniMaxLLMBackend.MiniMaxLLMBackendSettings();
+        Assert.Multiple(() =>
+        {
+            Assert.That(settings.ApiKey, Is.EqualTo(""));
+            Assert.That(settings.BaseUrl, Is.EqualTo("https://api.minimax.io/v1"));
+            Assert.That(settings.Model, Is.EqualTo("MiniMax-M2.7"));
+            Assert.That(settings.Temperature, Is.EqualTo(0.7));
+            Assert.That(settings.MaxTokens, Is.EqualTo(0));
+            Assert.That(settings.AllowIdle, Is.False);
+            Assert.That(settings.TimeoutSeconds, Is.EqualTo(120));
+        });
+    }
+
+    [Test]
+    public void SupportedFeatures_ContainsLlmAndRemoteLlm()
+    {
+        var backend = new MiniMaxLLMBackend();
+        var features = backend.SupportedFeatures.ToList();
+        Assert.Multiple(() =>
+        {
+            Assert.That(features, Contains.Item("llm"));
+            Assert.That(features, Contains.Item("remote_llm"));
+        });
+    }
+
+    [Test]
+    public async Task FreeMemory_ReturnsFalse()
+    {
+        var backend = new MiniMaxLLMBackend();
+        bool result = await backend.FreeMemory(true);
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void Init_WithoutApiKey_ThrowsInvalidOperationException()
+    {
+        var backend = new MiniMaxLLMBackend();
+        backend.SettingsRaw = new MiniMaxLLMBackend.MiniMaxLLMBackendSettings { ApiKey = "" };
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await backend.Init());
+    }
+
+    [Test]
+    public void Init_WithWhitespaceApiKey_ThrowsInvalidOperationException()
+    {
+        var backend = new MiniMaxLLMBackend();
+        backend.SettingsRaw = new MiniMaxLLMBackend.MiniMaxLLMBackendSettings { ApiKey = "   " };
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await backend.Init());
+    }
+
+    [Test]
+    public void Generate_WithoutInit_ThrowsInvalidOperationException()
+    {
+        var backend = new MiniMaxLLMBackend();
+        var input = new LLMs.LLMParamInput { UserMessage = "Hello" };
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await backend.Generate(input));
+    }
+
+    [Test]
+    public void GenerateLive_WithoutInit_ThrowsInvalidOperationException()
+    {
+        var backend = new MiniMaxLLMBackend();
+        var input = new LLMs.LLMParamInput { UserMessage = "Hello" };
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await backend.GenerateLive(input, "batch-1", _ => { }));
+    }
+}

--- a/tests/SwarmUI.Tests/SwarmUI.Tests.csproj
+++ b/tests/SwarmUI.Tests/SwarmUI.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="NUnit" Version="4.0.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SwarmUI.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Adds **MiniMax Cloud LLM** as a new built-in LLM backend provider, extending `AbstractLLMBackend`.

[MiniMax](https://platform.minimaxi.com) offers OpenAI-compatible chat completion APIs with models like **MiniMax-M2.7** (1M context), **MiniMax-M2.5**, and **MiniMax-M2.5-highspeed** (204K context).

### What is included

- **`MiniMaxLLMBackend.cs`** with full implementation:
  - Non-streaming (`Generate`) and streaming SSE (`GenerateLive`) support
  - Automatic think-tag stripping for M2.5+ reasoning models
  - Temperature clamping (0.0 to 1.0)
  - Configurable API key, base URL, model, max tokens, and timeout
  - Idle state support for unreachable API
- **Backend registration** in `BackendHandler` as `minimax_llm`
- **14 unit tests + 3 integration tests** (NUnit test project)
- **README** updated to mention MiniMax as a built-in LLM backend

### Configuration

Users add the backend via the UI (Server > Backends > Add Backend > MiniMax Cloud LLM), then set:
- `ApiKey` from https://platform.minimaxi.com
- `Model` defaults to `MiniMax-M2.7`
- `Temperature`, `MaxTokens`, `TimeoutSeconds` for optional tuning

## Test plan

- [ ] Unit tests pass: `dotnet test tests/SwarmUI.Tests/ --filter Category!=Integration`
- [ ] Integration tests pass with `MINIMAX_API_KEY` set
- [ ] Backend appears in Server > Backends > Add Backend dropdown
- [ ] Generate and streaming generate work via the LLM chat UI