### PR TITLE
Adds VideoStages and AceStepFun extensions

### DIFF
--- a/launchtools/extension_list.fds
+++ b/launchtools/extension_list.fds
@@ -244,3 +244,19 @@ DownloaderHelper:
     license: MIT
     tags:
     - tools
+
+VideoStages:
+    author: Juan Treminio
+    description: Allows adding multiple video stages to your workflows, as well as automatically using generate audio.
+    url: https://github.com/jtreminio/SwarmUI-VideoStages
+    license: MIT
+    tags:
+    - tools
+
+AceStepFun:
+    author: Juan Treminio
+    description: More advanced AceStep 1.5 text-to-audio support for SwarmUI. Works in tandem with the VideoStages to use AceStep audio in LTX2 videos.
+    url: https://github.com/jtreminio/SwarmUI-AceStepFun
+    license: MIT
+    tags:
+    - tools


### PR DESCRIPTION
[VideoStages](https://github.com/jtreminio/SwarmUI-VideoStages) allows adding _n_-count video stages to your workflow. This works well with LTX as you can upscale videos smoothly.

When in a image2video workflow, this extension allows a user to select the stage they want to reference an image from. For example, if a user creates a 1024-side base image, then downscales to 512-side to generate the initial video, the user can select one of Base, Refiner, or Generated for the reference image. Base will use the original 1024-side, Refiner will use the 512-side, Generated will use the generated video from the initial image2video stage. Using the Base allows highest quality as the user upscales their video through several video stages.

The extension also comes with a handy `SwarmAudioLengthToFrames` node that calculates the video frames using an audio input and the desired FPS.

<img width="353" height="1498" alt="image" src="https://github.com/user-attachments/assets/cd315f63-6d67-45a8-904a-fd09493aa78f" />

[AceStepFun](https://github.com/jtreminio/SwarmUI-AceStepFun) adds extra parameters to Swarm's AceStep support. If user selects an audio model for a regular text2audio workflow, and enables the extension, AceStepFun will modify the default workflow in-place. It allows using the Base or SFT versions of AceStep, selecting CFG and steps, and choosing the 4b LM vs the default 1.7b.

It also adds an `<audio>` section to prompt. This works the same as `<video>`. I had to add `<audio>` instead of using `<param[text2audio prompt]:foo>` because `param` is parsed before other extensions like MagicPrompt.

<img width="367" height="610" alt="image" src="https://github.com/user-attachments/assets/e76ea4f6-eb89-43a7-93de-a215677d3c3f" />

Additionally, the two extensions work in tandem:

A user can create a text2video or img2video workflow, select the "Connect Audio to Video" option in VideoStages, add AceStepFun to the workflow. The VideoStages extension will auto-detect the audio nodes and automatically connect the audio output to the video input, allowing a user to use AceStep music in their LTX videos.

My music videos have all been generated in this manner.