### PR TITLE
add drop-to-replace functionality for image prompt drop zone

### DIFF
--- a/src/wwwroot/css/genpage.css
+++ b/src/wwwroot/css/genpage.css
@@ -1113,7 +1113,7 @@ body {
     cursor: pointer;
 }
 .alt-prompt-image-container.image-drop-replace-target .alt-prompt-image {
-    outline: 2px solid var(--box-selected-border-stronger);
+    outline: 4px solid var(--emphasis);
     border-radius: 5px;
 }
 .image-clear-button {

--- a/src/wwwroot/css/genpage.css
+++ b/src/wwwroot/css/genpage.css
@@ -1075,6 +1075,7 @@ body {
     position: relative;
     background-color: color-mix(in srgb, transparent 80%, var(--background));
     transition: background-color 0.2s ease-out;
+    margin: 0 2px;
 }
 .alt-prompt-image {
     max-height: 128px;
@@ -1110,6 +1111,10 @@ body {
     background-color: color-mix(in srgb, var(--red) 70%, black) !important;
     border: 1px solid black;
     cursor: pointer;
+}
+.alt-prompt-image-container.image-drop-replace-target .alt-prompt-image {
+    outline: 2px solid var(--box-selected-border-stronger);
+    border-radius: 5px;
 }
 .image-clear-button {
     vertical-align: middle;

--- a/src/wwwroot/js/genpage/main.js
+++ b/src/wwwroot/js/genpage/main.js
@@ -554,7 +554,9 @@ function imagePromptAddImage(file) {
     if (replaceTarget && !existingImage) {
         replaceTarget = null;
     }
-    readFileAsDataURL(file, (data) => {
+    let reader = new FileReader();
+    reader.onload = (e) => {
+        let data = e.target.result;
         if (replaceTarget && !replaceTarget.isConnected) {
             imagePromptAddImage(file);
             return;
@@ -587,7 +589,8 @@ function imagePromptAddImage(file) {
         clearButton.style.display = '';
         showRevisionInputs(true);
         genTabLayout.altPromptSizeHandle();
-    });
+    };
+    reader.readAsDataURL(file);
 }
 
 function imagePromptInputHandler() {

--- a/src/wwwroot/js/genpage/main.js
+++ b/src/wwwroot/js/genpage/main.js
@@ -537,7 +537,7 @@ function setPromptImageReplaceTarget(target) {
 }
 
 function getPromptImageDropReplaceTarget(e) {
-    if (!e || !e.dataTransfer || !e.target || !e.target.closest || uiImprover.getFileList(e.dataTransfer, e).length == 0) {
+    if (uiImprover.getFileList(e.dataTransfer, e).length == 0) {
         return null;
     }
     let target = e.target.closest('.alt-prompt-image-container');

--- a/src/wwwroot/js/genpage/main.js
+++ b/src/wwwroot/js/genpage/main.js
@@ -524,33 +524,70 @@ function autoRevealRevision() {
     }
 }
 
+let promptImageReplaceTarget = null;
+
+function setPromptImageReplaceTarget(target) {
+    if (promptImageReplaceTarget) {
+        promptImageReplaceTarget.classList.remove('image-drop-replace-target');
+    }
+    promptImageReplaceTarget = target;
+    if (promptImageReplaceTarget) {
+        promptImageReplaceTarget.classList.add('image-drop-replace-target');
+    }
+}
+
+function getPromptImageDropReplaceTarget(e) {
+    if (!e || !e.dataTransfer || !e.target || !e.target.closest || uiImprover.getFileList(e.dataTransfer, e).length == 0) {
+        return null;
+    }
+    let target = e.target.closest('.alt-prompt-image-container');
+    if (!target || !target.querySelector('.alt-prompt-image')) {
+        return null;
+    }
+    return target;
+}
+
 function imagePromptAddImage(file) {
-    let clearButton = getRequiredElementById('alt_prompt_image_clear_button');
-    let promptImageArea = getRequiredElementById('alt_prompt_image_area');
-    let reader = new FileReader();
-    reader.onload = (e) => {
-        let data = e.target.result;
-        let imageContainer = createDiv(null, 'alt-prompt-image-container');
-        let imageRemoveButton = createSpan(null, 'alt-prompt-image-container-remove-button', '&times;');
-        imageRemoveButton.addEventListener('click', (e) => {
-            imageContainer.remove();
-            autoRevealRevision();
-            genTabLayout.altPromptSizeHandle();
-        });
-        imageRemoveButton.title = 'Remove this image';
-        imageContainer.appendChild(imageRemoveButton);
-        let imageObject = new Image();
-        imageObject.src = data;
-        imageObject.height = 128;
-        imageObject.className = 'alt-prompt-image';
-        imageObject.dataset.filedata = data;
-        imageContainer.appendChild(imageObject);
+    let replaceTarget = promptImageReplaceTarget;
+    setPromptImageReplaceTarget(null);
+    let existingImage = replaceTarget ? replaceTarget.querySelector('.alt-prompt-image') : null;
+    if (replaceTarget && !existingImage) {
+        replaceTarget = null;
+    }
+    readFileAsDataURL(file, (data) => {
+        if (replaceTarget && !replaceTarget.isConnected) {
+            imagePromptAddImage(file);
+            return;
+        }
+        if (existingImage) {
+            existingImage.src = data;
+            existingImage.height = 128;
+            existingImage.dataset.filedata = data;
+        }
+        else {
+            let promptImageArea = getRequiredElementById('alt_prompt_image_area');
+            let imageContainer = createDiv(null, 'alt-prompt-image-container');
+            let imageRemoveButton = createSpan(null, 'alt-prompt-image-container-remove-button', '&times;');
+            imageRemoveButton.addEventListener('click', () => {
+                imageContainer.remove();
+                autoRevealRevision();
+                genTabLayout.altPromptSizeHandle();
+            });
+            imageRemoveButton.title = 'Remove this image';
+            imageContainer.appendChild(imageRemoveButton);
+            let imageObject = new Image();
+            imageObject.src = data;
+            imageObject.height = 128;
+            imageObject.className = 'alt-prompt-image';
+            imageObject.dataset.filedata = data;
+            imageContainer.appendChild(imageObject);
+            promptImageArea.appendChild(imageContainer);
+        }
+        let clearButton = getRequiredElementById('alt_prompt_image_clear_button');
         clearButton.style.display = '';
         showRevisionInputs(true);
-        promptImageArea.appendChild(imageContainer);
         genTabLayout.altPromptSizeHandle();
-    };
-    reader.readAsDataURL(file);
+    });
 }
 
 function imagePromptInputHandler() {
@@ -574,6 +611,25 @@ function imagePromptInputHandler() {
             }
         }
     });
+    let updateReplaceTarget = (e) => {
+        setPromptImageReplaceTarget(getPromptImageDropReplaceTarget(e));
+    };
+    dragArea.addEventListener('dragenter', updateReplaceTarget, true);
+    dragArea.addEventListener('dragover', updateReplaceTarget, true);
+    dragArea.addEventListener('dragleave', (e) => {
+        if (!dragArea.contains(e.relatedTarget)) {
+            setPromptImageReplaceTarget(null);
+        }
+    }, true);
+    dragArea.addEventListener('drop', (e) => {
+        setPromptImageReplaceTarget(getPromptImageDropReplaceTarget(e));
+    }, true);
+    document.addEventListener('drop', () => {
+        setPromptImageReplaceTarget(null);
+    }, true);
+    document.addEventListener('dragend', () => {
+        setPromptImageReplaceTarget(null);
+    }, true);
 }
 imagePromptInputHandler();
 

--- a/src/wwwroot/js/util.js
+++ b/src/wwwroot/js/util.js
@@ -744,6 +744,18 @@ function readFileText(file, handler) {
     reader.readAsText(file);
 }
 
+/** Reads the given file as a data URL and passes the result to the given handler. Ignores null file inputs. */
+function readFileAsDataURL(file, handler) {
+    if (!file) {
+        return;
+    }
+    let reader = new FileReader();
+    reader.onload = (e) => {
+        handler(e.target.result);
+    };
+    reader.readAsDataURL(file);
+}
+
 /** Converts a number to a string of letters, where 1=a, 2=b, 3=c, ..., 26=aa, 27=ab, etc. */
 function numberToLetters(id) {
     if (id > 26) {

--- a/src/wwwroot/js/util.js
+++ b/src/wwwroot/js/util.js
@@ -744,18 +744,6 @@ function readFileText(file, handler) {
     reader.readAsText(file);
 }
 
-/** Reads the given file as a data URL and passes the result to the given handler. Ignores null file inputs. */
-function readFileAsDataURL(file, handler) {
-    if (!file) {
-        return;
-    }
-    let reader = new FileReader();
-    reader.onload = (e) => {
-        handler(e.target.result);
-    };
-    reader.readAsDataURL(file);
-}
-
 /** Converts a number to a string of letters, where 1=a, 2=b, 3=c, ..., 26=aa, 27=ab, etc. */
 function numberToLetters(id) {
     if (id > 26) {


### PR DESCRIPTION
## add drop-to-replace functionality for image prompt drop zone

- adds drag event listeners to image prompt dropzone to watch for file replacements
- shows ~a `2px` white~ `outline: 4px solid var(--emphasis)` to indicate file will be replaced
- adds a `2px` margin to images in drop zone to prevent outline overlap