### PR TITLE
add check to ensure CLIP is embedded before saving to prevent crash during LoRA extraction

### DIFF
--- a/src/BuiltinExtensions/ComfyUIBackend/ExtraNodes/SwarmComfyCommon/SwarmExtractLora.py
+++ b/src/BuiltinExtensions/ComfyUIBackend/ExtraNodes/SwarmComfyCommon/SwarmExtractLora.py
@@ -114,7 +114,11 @@ class SwarmExtractLora:
         other_data = other_model.model_state_dict()
         key_count = len(base_data.keys())
         if save_clip:
-            key_count += len(base_model_clip.get_sd().keys())
+            if base_model_clip is None or other_model_clip is None:
+                print("Warning: save_clip is True but CLIP model(s) are unavailable (model may not have embedded CLIP, e.g. Flux), skipping CLIP extraction")
+                save_clip = False
+            else:
+                key_count += len(base_model_clip.get_sd().keys())
         pbar = comfy.utils.ProgressBar(key_count)
         class Helper:
             steps = 0


### PR DESCRIPTION
https://github.com/mcmonkeyprojects/SwarmUI/issues/1330

This provides a safeguard in the Python code to ensure `base_model_clip` and `other_model_clip` are set before extracting the embedded CLIP.
Flux Checkpoints in the `Stable-Diffusion` directory are treated as regular checkpoints, and the check for `doClip` is based on the directory structure:

```
// in ComfyUIWebAPI.cs
bool doClip = !baseModelData.IsDiffusionModelsFormat && !otherModelData.IsDiffusionModelsFormat

...
...

// in T2IModel.cs
public bool IsDiffusionModelsFormat
    {
        get
        {
            string cleaned = OriginatingFolderPath.Replace('\\', '/').TrimEnd('/').ToLowerFast();
            return cleaned.EndsWithFast("/unet") || cleaned.EndsWithFast("/diffusion_models"); // Hacky but it works for now
        }
    }
```

It seems like a long term goal would be to check whether or not checkpoints in the `Stable-Diffusion` directory contain an embedded text encoder, and what that text encoder is (like CLIP or T5). As far as I know that is not reliably present in checkpoint metadata.