### PR TITLE
Allow using video for ControlNet for target type image

### DIFF
--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
@@ -1098,6 +1098,16 @@ public class WorkflowGeneratorSteps
                     {
                         throw new SwarmUserErrorException("Cannot use ControlNet without a model selected.");
                     }
+                    if (imageNodeActual.DataType == WGNodeData.DT_VIDEO && !g.IsVideoModel())
+                    {
+                        string singleFrame = g.CreateNode("ImageFromBatch", new JObject()
+                        {
+                            ["image"] = imageNodeActual.Path,
+                            ["batch_index"] = 0,
+                            ["length"] = 1
+                        });
+                        imageNodeActual = imageNodeActual.WithPath([singleFrame, 0], WGNodeData.DT_IMAGE);
+                    }
                     if (controlModel.ModelClass?.ID?.EndsWith("/control-diffpatch") ?? false)
                     {
                         string modelPatchLoader = g.CreateNode("ModelPatchLoader", new JObject()

--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
@@ -1084,6 +1084,17 @@ public class WorkflowGeneratorSteps
                         if (g.UserInput.Get(T2IParamTypes.ControlNetPreviewOnly))
                         {
                             g.CurrentMedia = imageNodeActual.WithPath(preprocActual);
+                            if (g.CurrentMedia.DataType == WGNodeData.DT_VIDEO)
+                            {
+                                string resized = g.CreateNode("ResizeImageMaskNode", new JObject()
+                                {
+                                    ["input"] = g.CurrentMedia.Path,
+                                    ["resize_type"] = "scale to multiple",
+                                    ["resize_type.multiple"] = 2,
+                                    ["scale_method"] = "lanczos"
+                                });
+                                g.CurrentMedia = g.CurrentMedia.WithPath([resized, 0]);
+                            }
                             g.CurrentMedia.SaveOutput(g.CurrentVae, g.CurrentAudioVae, id: "9");
                             g.SkipFurtherSteps = true;
                             return;

--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
@@ -1081,25 +1081,22 @@ public class WorkflowGeneratorSteps
                     {
                         JArray preprocActual = g.CreatePreprocessor(preprocessor, imageNodeActual);
                         g.NodeHelpers["controlnet_preprocessor"] = $"{preprocActual[0]}";
+                        imageNodeActual = imageNodeActual.WithPath(preprocActual);
+                        string multipleOf8 = g.CreateNode("ResizeImageMaskNode", new JObject()
+                        {
+                            ["input"] = imageNodeActual.Path,
+                            ["resize_type"] = "scale to multiple",
+                            ["resize_type.multiple"] = 8,
+                            ["scale_method"] = "lanczos"
+                        });
+                        imageNodeActual = imageNodeActual.WithPath([multipleOf8, 0]);
                         if (g.UserInput.Get(T2IParamTypes.ControlNetPreviewOnly))
                         {
-                            g.CurrentMedia = imageNodeActual.WithPath(preprocActual);
-                            if (g.CurrentMedia.DataType == WGNodeData.DT_VIDEO)
-                            {
-                                string resized = g.CreateNode("ResizeImageMaskNode", new JObject()
-                                {
-                                    ["input"] = g.CurrentMedia.Path,
-                                    ["resize_type"] = "scale to multiple",
-                                    ["resize_type.multiple"] = 8,
-                                    ["scale_method"] = "lanczos"
-                                });
-                                g.CurrentMedia = g.CurrentMedia.WithPath([resized, 0]);
-                            }
+                            g.CurrentMedia = imageNodeActual;
                             g.CurrentMedia.SaveOutput(g.CurrentVae, g.CurrentAudioVae, id: "9");
                             g.SkipFurtherSteps = true;
                             return;
                         }
-                        imageNodeActual = imageNodeActual.WithPath(preprocActual);
                     }
                     else if (g.UserInput.Get(T2IParamTypes.ControlNetPreviewOnly))
                     {

--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
@@ -1090,7 +1090,7 @@ public class WorkflowGeneratorSteps
                                 {
                                     ["input"] = g.CurrentMedia.Path,
                                     ["resize_type"] = "scale to multiple",
-                                    ["resize_type.multiple"] = 2,
+                                    ["resize_type.multiple"] = 8,
                                     ["scale_method"] = "lanczos"
                                 });
                                 g.CurrentMedia = g.CurrentMedia.WithPath([resized, 0]);

--- a/src/wwwroot/css/genpage.css
+++ b/src/wwwroot/css/genpage.css
@@ -1218,7 +1218,7 @@ body {
     height: 2px;
     background-color: var(--green);
 }
-.controlnet-preview-result img {
+.controlnet-preview-result img, .controlnet-preview-result video {
     max-width: 200px;
     max-height: 200px;
     margin-left: 2rem;

--- a/src/wwwroot/js/genpage/gentab/params.js
+++ b/src/wwwroot/js/genpage/gentab/params.js
@@ -1490,10 +1490,25 @@ function controlnetShowPreview() {
             if (!data.image) {
                 return;
             }
-            let imgElem = document.createElement('img');
-            imgElem.src = data.image;
             let resultBox = createDiv(null, 'controlnet-preview-result');
-            resultBox.append(imgElem);
+            let isVideo = isVideoExt(data.image);
+            if (isVideo) {
+                let vidElem = document.createElement('video');
+                vidElem.loop = true;
+                vidElem.autoplay = true;
+                vidElem.muted = true;
+                vidElem.controls = true;
+                let sourceObj = document.createElement('source');
+                sourceObj.src = data.image;
+                sourceObj.type = isVideo;
+                vidElem.append(sourceObj);
+                resultBox.append(vidElem);
+            }
+            else {
+                let imgElem = document.createElement('img');
+                imgElem.src = data.image;
+                resultBox.append(imgElem);
+            }
             clearPreview();
             previewArea.append(resultBox);
         });


### PR DESCRIPTION
Note that "Preview" might still not work here.

Hitting the button results in:

```ComfyUI execution error: ffmpeg failed: [libx264 @ 0x15d06500] height not divisible by 2 (1024x1497)
[vost#0:0/libx264 @ 0x15d05fc0] Error while opening encoder - maybe incorrect parameters such as bit_rate, rate, width or height.
[vf#0:0 @ 0x15cfa340] Error sending frames to consumers: Generic error in an external library
[vf#0:0 @ 0x15cfa340] Task finished with error code: -542398533 (Generic error in an external library)
[vf#0:0 @ 0x15cfa340] Terminating thread with return code -542398533 (Generic error in an external library)
[vost#0:0/libx264 @ 0x15d05fc0] Could not open encoder before EOF
[vost#0:0/libx264 @ 0x15d05fc0] Task finished with error code: -22 (Invalid argument)
[vost#0:0/libx264 @ 0x15d05fc0] Terminating thread with return code -22 (Invalid argument)
[out#0/mp4 @ 0x15d05640] Nothing was written into output file, because at least one of its streams received no packets.
```

I worked around this by [following your example here](https://github.com/mcmonkeyprojects/SwarmUI/blob/master/src/wwwroot/js/genpage/gentab/currentimagehandler.js#L856-L868).

<img width="2191" height="1115" alt="CleanShot 2026-05-01 at 18 43 43" src="https://github.com/user-attachments/assets/f58764c6-f05b-4d7e-a18c-81c140c682f9" />
