### PR TITLE
Set DWPreprocessor.bbox_detector = yolox_l.torchscript.pt

### DIFF
--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGenerator.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGenerator.cs
@@ -2138,6 +2138,10 @@ public partial class WorkflowGenerator
                         {
                             n["inputs"]["resolution"] = (int)Math.Round(Math.Sqrt(UserInput.GetImageWidth() * UserInput.GetImageHeight()) / 64) * 64;
                         }
+                        else if (key == "bbox_detector" && preprocessor == "DWPreprocessor")
+                        {
+                            n["inputs"]["bbox_detector"] = "yolox_l.torchscript.pt";
+                        }
                         else if (data.Count() == 2 && data[1] is JObject settings && settings.TryGetValue("default", out JToken defaultValue))
                         {
                             n["inputs"][key] = defaultValue;


### PR DESCRIPTION
As noted in discord, I ran some benchmarks:

* `yolox_l.torchscript.pt` = **7s**
* `yolox_l.onnx` = **51s**
* `yolo_nas_l_fp16.onnx` = 37s
* `yolo_nas_m_fp16.onnx` = 32s
* `yolo_nas_s_fp16.onnx` = 25s

All the onnx choices give an error, they require cuda 12:

```onnx slower due to: [E:onnxruntime:Default, provider_bridge_ort.cc:2364 TryGetProviderInfo_CUDA] /onnxruntime_src/onnxruntime/core/session/provider_bridge_ort.cc:1957 onnxruntime::Provider& onnxruntime::ProviderLibrary::Get() [ONNXRuntimeError] : 1 : FAIL : Failed to load library /usr/local/lib/python3.12/dist-packages/onnxruntime/capi/libonnxruntime_providers_cuda.so with error: libcublasLt.so.12: cannot open shared object file: No such file or directory```

Switching to `yolox_l.torchscript.pt` instead is safe because `pose_estimator` already uses `dw-ll_ucoco_384_bs5.torchscript.pt` so torchscript is assumed.

<img width="916" height="414" alt="CleanShot 2026-05-01 at 19 02 17" src="https://github.com/user-attachments/assets/ff45ca9a-201e-42ab-bfac-1e77a9061ebb" />
