### PR TITLE
Add AltTriggerPhraseBtn to extension list

### DIFF
--- a/launchtools/extension_list.fds
+++ b/launchtools/extension_list.fds
@@ -294,7 +294,6 @@ AltTriggerPhraseBtn:
     description: Changes the appearance of the trigger phrase copy button. 
     url: https://github.com/mrblomblo/AltTriggerPhraseBtn
     license: MIT
-    ci-test: true
     tags:
     - conflicts
     - ui

--- a/launchtools/extension_list.fds
+++ b/launchtools/extension_list.fds
@@ -288,3 +288,13 @@ AceStepFun:
     ci-test: true
     tags:
     - tools
+
+AltTriggerPhraseBtn
+    author: Blomblo
+    description: Changes the appearance of the trigger phrase copy button. 
+    url: https://github.com/mrblomblo/AltTriggerPhraseBtn
+    license: MIT
+    ci-test: true
+    tags:
+    - conflicts
+    - ui

--- a/launchtools/extension_list.fds
+++ b/launchtools/extension_list.fds
@@ -289,7 +289,7 @@ AceStepFun:
     tags:
     - tools
 
-AltTriggerPhraseBtn
+AltTriggerPhraseBtn:
     author: Blomblo
     description: Changes the appearance of the trigger phrase copy button. 
     url: https://github.com/mrblomblo/AltTriggerPhraseBtn


### PR DESCRIPTION
Adds the [AltTriggerPhraseBtn](https://github.com/mrblomblo/AltTriggerPhraseBtn) extension to the extension list.

File edited in GitHub's online editor, so I hope the formatting is correct.