### PR TITLE
Expose the context parameter during creation of TensorRT engines

### DIFF
--- a/src/BuiltinExtensions/ComfyUIBackend/ComfyUIWebAPI.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/ComfyUIWebAPI.cs
@@ -266,7 +266,7 @@ public static class ComfyUIWebAPI
     };
 
     /// <summary>API route to create a TensorRT model.</summary>
-    public static async Task<JObject> DoTensorRTCreateWS(Session session, WebSocket ws, string model, string aspect, string aspectRange, int optBatch, int maxBatch)
+    public static async Task<JObject> DoTensorRTCreateWS(Session session, WebSocket ws, string model, string aspect, string aspectRange, int optBatch, int maxBatch, int contextLen = 75)
     {
         if (ModelsAPI.TryGetRefusalForModel(session, model, out JObject refusal))
         {
@@ -336,7 +336,7 @@ public static class ComfyUIWebAPI
                     ["batch_size_opt"] = optBatch,
                     ["height_opt"] = prefY,
                     ["width_opt"] = prefX,
-                    ["context_opt"] = 1,
+                    ["context_opt"] = contextLen / 75,
                     ["num_video_frames"] = 25
                 }
             };
@@ -360,8 +360,8 @@ public static class ComfyUIWebAPI
                     ["width_opt"] = prefX,
                     ["width_max"] = Math.Clamp(maxX, 256, 4096),
                     ["context_min"] = 1,
-                    ["context_opt"] = 1,
-                    ["context_max"] = 128,
+                    ["context_opt"] = contextLen / 75,
+                    ["context_max"] = Math.Max(contextLen / 75, 128),
                     ["num_video_frames"] = 25
                 }
             };

--- a/src/Pages/_Generate/GenTabModals.cshtml
+++ b/src/Pages/_Generate/GenTabModals.cshtml
@@ -247,6 +247,7 @@
             </select>
             <br>Preferred Batch Size: <input type="number" class="auto-number" id="tensorrt_batch_size" value="1" min="1" max="64" />
             <br>Max Batch Size: <input type="number" class="auto-number" id="tensorrt_max_batch_size" value="4" min="1" max="64" />
+            <br>CLIP Context Length (tokens): <input type="number" class="auto-number" id="tensorrt_context" value="75" min="75" max="300" />
             <div id="tensorrt_create_result_box">
             </div>
         </div>

--- a/src/Pages/_Generate/GenTabModals.cshtml
+++ b/src/Pages/_Generate/GenTabModals.cshtml
@@ -247,7 +247,7 @@
             </select>
             <br>Preferred Batch Size: <input type="number" class="auto-number" id="tensorrt_batch_size" value="1" min="1" max="64" />
             <br>Max Batch Size: <input type="number" class="auto-number" id="tensorrt_max_batch_size" value="4" min="1" max="64" />
-            <br>CLIP Context Length (tokens): <input type="number" class="auto-number" id="tensorrt_context" value="75" min="75" max="300" />
+            <br>CLIP Context Length (tokens): <input type="number" class="auto-number" id="tensorrt_context" value="75" min="75" max="300" step="75" />
             <div id="tensorrt_create_result_box">
             </div>
         </div>

--- a/src/wwwroot/js/genpage/gentab/models.js
+++ b/src/wwwroot/js/genpage/gentab/models.js
@@ -1036,6 +1036,7 @@ function trt_modal_create() {
     let rangeSelect = getRequiredElementById('tensorrt_aspect_range');
     let batchSize = getRequiredElementById('tensorrt_batch_size');
     let maxBatch = getRequiredElementById('tensorrt_max_batch_size');
+    let contextLen = getRequiredElementById('tensorrt_context');
     let createButton = getRequiredElementById('trt_create_button');
     let resultBox = getRequiredElementById('tensorrt_create_result_box');
     let data = {
@@ -1043,7 +1044,8 @@ function trt_modal_create() {
         'aspect': aspectSelect.value,
         'aspectRange': rangeSelect.value,
         'optBatch': batchSize.value,
-        'maxBatch': maxBatch.value
+        'maxBatch': maxBatch.value,
+        'contextLen': contextLen.value
     };
     createButton.disabled = true;
     resultBox.innerText = 'Creating TensorRT engine, please wait...';


### PR DESCRIPTION
A simple tweak that exposes previously hardcoded context parameter (was hardcoded to 1) when creating TensorRT engines. Now users will get to actually select how big context support they want in the dialog, along with other params.
This allows the created engines to actually work with prompts exceeding 75 tokens.
If user inputs 75 in dialog, the value is set to 1, if 150 then 2, so on.