### PR TITLE
Add support for extension private deps

### DIFF
--- a/src/Core/ExtensionsManager.cs
+++ b/src/Core/ExtensionsManager.cs
@@ -12,8 +12,7 @@ public class SwarmExtensionLoadContext : AssemblyLoadContext
 {
     private readonly string ExtensionDir;
 
-    public SwarmExtensionLoadContext(string name, string extensionDir)
-        : base(name, isCollectible: false)
+    public SwarmExtensionLoadContext(string name, string extensionDir) : base(name, isCollectible: false)
     {
         ExtensionDir = extensionDir;
     }
@@ -21,8 +20,14 @@ public class SwarmExtensionLoadContext : AssemblyLoadContext
     protected override Assembly Load(AssemblyName name)
     {
         // If the host already has this assembly (SwarmUI itself, ASP.NET Core, NuGet deps SwarmUI loaded), return null so the runtime resolves it from the default ALC. This preserves type identity for shared types.
-        try { Default.LoadFromAssemblyName(name); return null; }
-        catch (FileNotFoundException) { }
+        try {
+            Default.LoadFromAssemblyName(name);
+            return null;
+            }
+        catch (FileNotFoundException)
+        {
+            // Ignore the exception, we want to load the assembly from the extension's own output folder.
+        }
         // Otherwise probe the extension's own output folder. Extensions ship private deps as <Reference Private=true> with a HintPath, which MSBuild copies next to the extension DLL.
         string candidate = Path.Combine(ExtensionDir, name.Name + ".dll");
         return File.Exists(candidate) ? LoadFromAssemblyPath(candidate) : null;
@@ -72,8 +77,7 @@ public class ExtensionsManager
 
     private Assembly LoadInExtensionContext(string dllName, string targetPath)
     {
-        SwarmExtensionLoadContext ctx = ExtensionLoadContexts.GetOrAdd(dllName,
-            n => new SwarmExtensionLoadContext(n, Path.GetDirectoryName(targetPath)));
+        SwarmExtensionLoadContext ctx = ExtensionLoadContexts.GetOrAdd(dllName, n => new SwarmExtensionLoadContext(n, Path.GetDirectoryName(targetPath)));
         return ctx.LoadFromAssemblyPath(targetPath);
     }
 

--- a/src/Core/ExtensionsManager.cs
+++ b/src/Core/ExtensionsManager.cs
@@ -20,7 +20,8 @@ public class SwarmExtensionLoadContext : AssemblyLoadContext
     protected override Assembly Load(AssemblyName name)
     {
         // If the host already has this assembly (SwarmUI itself, ASP.NET Core, NuGet deps SwarmUI loaded), return null so the runtime resolves it from the default ALC. This preserves type identity for shared types.
-        try {
+        try
+        {
             Default.LoadFromAssemblyName(name);
             return null;
         }

--- a/src/Core/ExtensionsManager.cs
+++ b/src/Core/ExtensionsManager.cs
@@ -23,7 +23,7 @@ public class SwarmExtensionLoadContext : AssemblyLoadContext
         try {
             Default.LoadFromAssemblyName(name);
             return null;
-            }
+        }
         catch (FileNotFoundException)
         {
             // Ignore the exception, we want to load the assembly from the extension's own output folder.

--- a/src/Core/ExtensionsManager.cs
+++ b/src/Core/ExtensionsManager.cs
@@ -72,13 +72,9 @@ public class ExtensionsManager
     /// <summary>List of known online available extensions.</summary>
     public List<ExtensionInfo> KnownExtensions = [];
 
-    /// <summary>Per-extension load contexts, keyed by extension DLL name. Each extension gets its own <see cref="SwarmExtensionLoadContext"/> so private dependencies stay isolated from other extensions.</summary>
-    public ConcurrentDictionary<string, SwarmExtensionLoadContext> ExtensionLoadContexts = new();
-
     private Assembly LoadInExtensionContext(string dllName, string targetPath)
     {
-        SwarmExtensionLoadContext ctx = ExtensionLoadContexts.GetOrAdd(dllName, n => new SwarmExtensionLoadContext(n, Path.GetDirectoryName(targetPath)));
-        return ctx.LoadFromAssemblyPath(targetPath);
+        return new SwarmExtensionLoadContext(dllName, Path.GetDirectoryName(targetPath)).LoadFromAssemblyPath(targetPath);
     }
 
     public static string ReferenceCsproj =

--- a/src/Core/ExtensionsManager.cs
+++ b/src/Core/ExtensionsManager.cs
@@ -4,8 +4,30 @@ using Microsoft.AspNetCore.Html;
 using SwarmUI.Utils;
 using System.IO;
 using System.Reflection;
+using System.Runtime.Loader;
 
 namespace SwarmUI.Core;
+
+public class SwarmExtensionLoadContext : AssemblyLoadContext
+{
+    private readonly string ExtensionDir;
+
+    public SwarmExtensionLoadContext(string name, string extensionDir)
+        : base(name, isCollectible: false)
+    {
+        ExtensionDir = extensionDir;
+    }
+
+    protected override Assembly Load(AssemblyName name)
+    {
+        // If the host already has this assembly (SwarmUI itself, ASP.NET Core, NuGet deps SwarmUI loaded), return null so the runtime resolves it from the default ALC. This preserves type identity for shared types.
+        try { Default.LoadFromAssemblyName(name); return null; }
+        catch (FileNotFoundException) { }
+        // Otherwise probe the extension's own output folder. Extensions ship private deps as <Reference Private=true> with a HintPath, which MSBuild copies next to the extension DLL.
+        string candidate = Path.Combine(ExtensionDir, name.Name + ".dll");
+        return File.Exists(candidate) ? LoadFromAssemblyPath(candidate) : null;
+    }
+}
 
 public class ExtensionsManager
 {
@@ -44,6 +66,16 @@ public class ExtensionsManager
 
     /// <summary>List of known online available extensions.</summary>
     public List<ExtensionInfo> KnownExtensions = [];
+
+    /// <summary>Per-extension load contexts, keyed by extension DLL name. Each extension gets its own <see cref="SwarmExtensionLoadContext"/> so private dependencies stay isolated from other extensions.</summary>
+    public ConcurrentDictionary<string, SwarmExtensionLoadContext> ExtensionLoadContexts = new();
+
+    private Assembly LoadInExtensionContext(string dllName, string targetPath)
+    {
+        SwarmExtensionLoadContext ctx = ExtensionLoadContexts.GetOrAdd(dllName,
+            n => new SwarmExtensionLoadContext(n, Path.GetDirectoryName(targetPath)));
+        return ctx.LoadFromAssemblyPath(targetPath);
+    }
 
     public static string ReferenceCsproj =
         """
@@ -181,7 +213,7 @@ public class ExtensionsManager
         if (File.Exists(target) && !Program.IsDevMode)
         {
             Logs.Debug($"Don't need to rebuild extension {projFile}, already built.");
-            return Assembly.LoadFile(Path.GetFullPath(target));
+            return LoadInExtensionContext(dllName, Path.GetFullPath(target));
         }
         Logs.Debug($"Building extension project: {projFile}...");
         string buildParam = $"-p:BaseIntermediateOutputPath={Path.GetFullPath($"./src/obj/extensions/{dllName}/")};TargetName={dllName}-{hash}";
@@ -195,7 +227,7 @@ public class ExtensionsManager
         {
             Logs.Debug($"Successful build output for extension project {projFile}:\n{output}");
         }
-        return Assembly.LoadFile(Path.GetFullPath(target));
+        return LoadInExtensionContext(dllName, Path.GetFullPath(target));
     }
 
     public void PrepExtension(Type extType, bool isCore, string[] possible)

--- a/src/Core/ExtensionsManager.cs
+++ b/src/Core/ExtensionsManager.cs
@@ -8,30 +8,29 @@ using System.Runtime.Loader;
 
 namespace SwarmUI.Core;
 
-public class SwarmExtensionLoadContext : AssemblyLoadContext
+public class SwarmExtensionLoadContext(string name, string extensionDir) : AssemblyLoadContext(name, isCollectible: false)
 {
-    private readonly string ExtensionDir;
-
-    public SwarmExtensionLoadContext(string name, string extensionDir) : base(name, isCollectible: false)
-    {
-        ExtensionDir = extensionDir;
-    }
-
+    /// <summary>Host wins, then we probe the extension's folder for private deps.</summary>
     protected override Assembly Load(AssemblyName name)
     {
-        // If the host already has this assembly (SwarmUI itself, ASP.NET Core, NuGet deps SwarmUI loaded), return null so the runtime resolves it from the default ALC. This preserves type identity for shared types.
+        string candidate = Path.Combine(extensionDir, name.Name + ".dll");
+        // Host wins to keep type identity intact. If the extension also shipped its own copy, that's almost always a csproj misconfig (missing Private=false), so warn.
         try
         {
             Default.LoadFromAssemblyName(name);
+            if (File.Exists(candidate))
+            {
+                Logs.Warning($"Extension {Name} ships {name.Name}.dll but host already has it; using host copy. Set Private=false on that reference.");
+            }
             return null;
         }
-        catch (FileNotFoundException)
+        catch (FileNotFoundException) { }
+        if (!File.Exists(candidate))
         {
-            // Ignore the exception, we want to load the assembly from the extension's own output folder.
+            return null;
         }
-        // Otherwise probe the extension's own output folder. Extensions ship private deps as <Reference Private=true> with a HintPath, which MSBuild copies next to the extension DLL.
-        string candidate = Path.Combine(ExtensionDir, name.Name + ".dll");
-        return File.Exists(candidate) ? LoadFromAssemblyPath(candidate) : null;
+        Logs.Debug($"Extension {Name} loading private dep {name.Name} from {candidate}");
+        return LoadFromAssemblyPath(candidate);
     }
 }
 

--- a/src/Core/ExtensionsManager.cs
+++ b/src/Core/ExtensionsManager.cs
@@ -8,32 +8,6 @@ using System.Runtime.Loader;
 
 namespace SwarmUI.Core;
 
-public class SwarmExtensionLoadContext(string name, string extensionDir) : AssemblyLoadContext(name, isCollectible: false)
-{
-    /// <summary>Host wins, then we probe the extension's folder for private deps.</summary>
-    protected override Assembly Load(AssemblyName name)
-    {
-        string candidate = Path.Combine(extensionDir, name.Name + ".dll");
-        // Host wins to keep type identity intact. If the extension also shipped its own copy, that's almost always a csproj misconfig (missing Private=false), so warn.
-        try
-        {
-            Default.LoadFromAssemblyName(name);
-            if (File.Exists(candidate))
-            {
-                Logs.Warning($"Extension {Name} ships {name.Name}.dll but host already has it; using host copy. Set Private=false on that reference.");
-            }
-            return null;
-        }
-        catch (FileNotFoundException) { }
-        if (!File.Exists(candidate))
-        {
-            return null;
-        }
-        Logs.Debug($"Extension {Name} loading private dep {name.Name} from {candidate}");
-        return LoadFromAssemblyPath(candidate);
-    }
-}
-
 public class ExtensionsManager
 {
     /// <summary>All extensions currently loaded.</summary>
@@ -42,9 +16,38 @@ public class ExtensionsManager
     /// <summary>Hashset of folder names of all extensions currently loaded.</summary>
     public HashSet<string> LoadedExtensionFolders = [];
 
+    /// <summary>Hashset of dependency names that are considered "core" and should not be loaded from the extension's folder.</summary>
+    public HashSet<string> CoreDependencyNames = [];
+
     /// <summary>Simple holder of information about extensions available online.</summary>
     public record class ExtensionInfo(string Name, string Author, string License, string Description, string URL, string OldURL, string[] Tags, string[] FolderNames)
     {
+    }
+
+    private class SwarmExtensionLoadContext(ExtensionsManager manager, string name, string extensionDir) : AssemblyLoadContext(name, isCollectible: false)
+    {
+        /// <summary>Host wins, then we probe the extension's folder for private deps.</summary>
+        protected override Assembly Load(AssemblyName name)
+        {
+            string dependency = Path.Combine(extensionDir, name.Name + ".dll");
+            try
+            {
+                Default.LoadFromAssemblyName(name);
+                // We only get here if host successfully loads the assembly.
+                if (File.Exists(dependency) && !manager.CoreDependencyNames.Contains(name.Name))
+                {
+                    Logs.Warning($"Extension {Name} ships {name.Name}.dll but host already has it loaded; using host copy.");
+                }
+                return null;
+            }
+            catch (FileNotFoundException) { }
+            if (!File.Exists(dependency))
+            {
+                return null;
+            }
+            Logs.Debug($"Extension {Name} loading private dep {name.Name} from {dependency}");
+            return LoadFromAssemblyPath(dependency);
+        }
     }
 
     public static HtmlString HtmlTags(string[] tags)
@@ -74,7 +77,7 @@ public class ExtensionsManager
 
     private Assembly LoadInExtensionContext(string dllName, string targetPath)
     {
-        return new SwarmExtensionLoadContext(dllName, Path.GetDirectoryName(targetPath)).LoadFromAssemblyPath(targetPath);
+        return new SwarmExtensionLoadContext(this, dllName, Path.GetDirectoryName(targetPath)).LoadFromAssemblyPath(targetPath);
     }
 
     public static string ReferenceCsproj =
@@ -90,6 +93,11 @@ public class ExtensionsManager
     /// <summary>Initial call that prepares the extensions list.</summary>
     public async Task PrepExtensions()
     {
+        CoreDependencyNames =
+        [
+            .. AssemblyLoadContext.Default.Assemblies.Select(a => a.GetName().Name).Where(n => n is not null),
+            .. Directory.EnumerateFiles(AppContext.BaseDirectory, "*.dll").Select(Path.GetFileNameWithoutExtension)
+        ];
         await BuildPublicExtensionList();
         string[] builtins = [.. Directory.EnumerateDirectories("./src/BuiltinExtensions").Select(s => "src/" + s.Replace('\\', '/').AfterLast("/src/"))];
         string[] extras = Directory.Exists("./src/Extensions") ? [.. Directory.EnumerateDirectories("./src/Extensions/").Select(s => "src/" + s.Replace('\\', '/').AfterLast("/src/"))] : [];


### PR DESCRIPTION
The way this works for me is, in my extension's `.csproj` file:

```xml
  <ItemGroup>
    <Reference Include="ComfyTyped">
      <HintPath>lib/ComfyTyped.dll</HintPath>
    </Reference>
  </ItemGroup>
```

I've added the ComfyTyped dep to two of my extensions, one with it fully baked in and used, the other with a very small footprint, swarmui builds fine.

This PR's purpose is for each extension to define its own private dependency, where ExtensionA and ExtensionB both depend on LibA but might be different versions.

The simpler solution that does not guard against multiple extensions using the same dependency that might have differing versions is changing `return Assembly.LoadFile` to `return Assembly.LoadFrom` here:

* https://github.com/mcmonkeyprojects/SwarmUI/blob/master/src/Core/ExtensionsManager.cs#L184
* https://github.com/mcmonkeyprojects/SwarmUI/blob/master/src/Core/ExtensionsManager.cs#L198

Full disclosure as mentioned in Discord but important to note: This PR was created using Claude because C# build and dependency management confuses the heck out of me. I know the two proposed solutions work because I have a full test suite for my extensions, SwarmUI builds, and my extension with its private dependency works great.