### PR TITLE
Shows Image parameters (side view only) in columnar form for easier readability

### DIFF
--- a/src/wwwroot/css/genpage.css
+++ b/src/wwwroot/css/genpage.css
@@ -682,6 +682,10 @@ body {
 .param_view_block_model {
     background-color: color-mix(in srgb, transparent 99%, var(--tag-color));
 }
+.extras-wrapper-sideblock span.param_view_block .param_view_name {
+    display: inline-block;
+    min-width: 6rem;
+}
 .param_view {
     border-radius: 0.3rem;
     color: var(--text);

--- a/src/wwwroot/js/genpage/helpers/metadatahelpers.js
+++ b/src/wwwroot/js/genpage/helpers/metadatahelpers.js
@@ -233,7 +233,7 @@ let metadataKeyFormatCleaners = [];
 let promptCidMatcher = new RegExp('\<(.*?)//cid=\\d+>', 'g');
 
 function formatMetadataEntry(entry) {
-    return `<span class="param_view_block tag-text tag-type-${entry.hash}${entry.added}"><span class="param_view_name" title="${escapeHtmlNoBr(entry.keyTitle)}">${escapeHtml(entry.key)}</span>: ${entry.valueHtml}${entry.extras}</span>`;
+    return `<span class="param_view_block tag-text tag-type-${entry.hash}${entry.added}"><span class="param_view_name" title="${escapeHtmlNoBr(entry.keyTitle)}">${escapeHtml(entry.key)}:</span> ${entry.valueHtml}${entry.extras}</span>`;
 }
 
 function getFormattedMetadataEntries(metadata) {


### PR DESCRIPTION
When parameter data is viewed *beside* an image, the keys and values are easily confused.

This CSS tweak improves readability showing them in pseudo-columns. It also moves the `:` to the key's span.

Reference / screenshot:

https://discord.com/channels/1243166023859961988/1243185862234210389/1510800649011593367

Bottom mode display is not affected -- an enhancement could be made there, but would likely require adjusting the markup to use CSS grids.