### PR TITLE
Fixes thumbmail capture from CivitAI video previews

### DIFF
--- a/src/wwwroot/js/genpage/utiltab.js
+++ b/src/wwwroot/js/genpage/utiltab.js
@@ -371,7 +371,11 @@ class ModelDownloaderUtil {
                         let url = videos[0].url;
                         let video = document.createElement('video');
                         video.crossOrigin = 'Anonymous';
-                        video.onloadeddata = () => {
+                        video.preload = 'auto';
+                        video.onloadedmetadata = () => {
+                            video.currentTime = 0.001;
+                        };
+                        video.onseeked = () => {
                             let canvas = document.createElement('canvas');
                             canvas.width = video.videoWidth;
                             canvas.height = video.videoHeight;


### PR DESCRIPTION
`onloadeddata` fires when the browser has the first frame's data, but doesn't guarantee the video decoder has rendered it into a drawable state. Calling `drawImage` at that point captures a transparent PNG.

This fix seeks to a concrete timestamp and waits for `onseeked`, which fires only after the frame is fully decoded and ready to paint.