### PR TITLE
Add new extensions: SharpSplat, Spectrum, and WD14Tagger

### DIFF
--- a/launchtools/extension_list.fds
+++ b/launchtools/extension_list.fds
@@ -339,3 +339,4 @@ WD14Tagger:
     url: https://github.com/GlenCarpenter/SwarmUI-WD14Tagger
     license: MIT
     tags:
+    - tools

--- a/launchtools/extension_list.fds
+++ b/launchtools/extension_list.fds
@@ -323,11 +323,13 @@ SharpSplat:
     url: https://github.com/GlenCarpenter/SwarmUI-SharpSplat
     license: MIT
     tags:
+    - tabs
     - ui
+    - parameters
 
 Spectrum:
     author: Glen Carpenter
-    description: Integrates Spectrum diffusion sampling acceleration into SwarmUI's generation pipeline.
+    description: Adds support for an alternate sampling acceleration technique called 'Spectrum'.
     url: https://github.com/GlenCarpenter/SwarmUI-Spectrum
     license: MIT
     tags:
@@ -340,3 +342,4 @@ WD14Tagger:
     license: MIT
     tags:
     - tools
+    - parameters

--- a/launchtools/extension_list.fds
+++ b/launchtools/extension_list.fds
@@ -306,3 +306,27 @@ Epsilon-Scaling:
     tags:
     - parameters
     - nodes
+
+SharpSplat:
+    author: Glen Carpenter
+    description: Turns images into 3D Gaussian Splats directly inside the browser.
+    url: https://github.com/GlenCarpenter/SwarmUI-SharpSplat
+    license: MIT
+    tags:
+    - ui
+
+Spectrum:
+    author: Glen Carpenter
+    description: Integrates Spectrum diffusion sampling acceleration into SwarmUI's generation pipeline.
+    url: https://github.com/GlenCarpenter/SwarmUI-Spectrum
+    license: MIT
+    tags:
+    - parameters
+
+WD14Tagger:
+    author: Glen Carpenter
+    description: Adds automatic image tagging using booru-style taggers.
+    url: https://github.com/GlenCarpenter/SwarmUI-WD14Tagger
+    license: MIT
+    tags:
+    - tools


### PR DESCRIPTION
Adds 3 new extensions to the extensions list:

- SharpSplat - https://github.com/GlenCarpenter/SwarmUI-SharpSplat
- Spectrum - https://github.com/GlenCarpenter/SwarmUI-Spectrum
- WD14Tagger - https://github.com/GlenCarpenter/SwarmUI-WD14Tagger

I have added a basic tag to each but it was discussed we may need new tags for these.