### PR TITLE
Use Qwen3VL for ideogram4 instead of Qwen3

### DIFF
--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorModelSupport.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorModelSupport.cs
@@ -596,6 +596,11 @@ public partial class WorkflowGenerator
             return RequireClipModel("qwen_3_8b.safetensors", "https://huggingface.co/Comfy-Org/flux2-klein-9B/resolve/main/split_files/text_encoders/qwen_3_8b_fp4mixed.safetensors", "bbf16f981d98e16d080c566134814c4e9f6aadd0d0e1383c60bc44ba939d760d", T2IParamTypes.QwenModel);
         }
 
+        public string GetQwen3Vl8bModel()
+        {
+            return RequireClipModel("qwen3vl_8b_fp8_scaled.safetensors", "https://huggingface.co/Comfy-Org/Ideogram-4/resolve/main/text_encoders/qwen3vl_8b_fp8_scaled.safetensors", "4ba424cf62e51392e4d1a39933e803706f4e823c1065f36aaf149c6453f66bcd", T2IParamTypes.QwenModel);
+        }
+
         public string GetOvisQwenModel()
         {
             return RequireClipModel("ovis_2.5.safetensors", "https://huggingface.co/Comfy-Org/Ovis-Image/resolve/main/split_files/text_encoders/ovis_2.5.safetensors", "f453ee5e7a25cb23cf2adf7aae3e5b405f22097cb67f2cfcca029688cb3f740d", T2IParamTypes.QwenModel);
@@ -1105,7 +1110,7 @@ public partial class WorkflowGenerator
         }
         else if (IsIdeogram4())
         {
-            helpers.LoadClip("ideogram4", helpers.GetQwen3_8bModel());
+            helpers.LoadClip("ideogram4", helpers.GetQwen3Vl8bModel());
             helpers.DoVaeLoader(UserInput.SourceSession?.User?.Settings?.VAEs?.DefaultFlux2VAE, "flux-2", "flux2-vae");
         }
         else if (IsFlux() && (LoadingClip is null || LoadingVAE is null || UserInput.Get(T2IParamTypes.T5XXLModel) is not null || UserInput.Get(T2IParamTypes.ClipLModel) is not null))

--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorModelSupport.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorModelSupport.cs
@@ -598,7 +598,7 @@ public partial class WorkflowGenerator
 
         public string GetQwen3Vl8bModel()
         {
-            return RequireClipModel("qwen3vl_8b_nvfp4.safetensors", "https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/text_encoders/qwen3vl_8b_nvfp4.safetensors", "e462e9e0c3b9313ae17f82040d7c77beb92d7aef3e40692d7803228dab7c3b98", T2IParamTypes.QwenModel);
+            return RequireClipModel("qwen3vl_8b_nvfp4.safetensors", "https://huggingface.co/Comfy-Org/Ideogram-4/resolve/main/text_encoders/qwen3vl_8b_nvfp4.safetensors", "e462e9e0c3b9313ae17f82040d7c77beb92d7aef3e40692d7803228dab7c3b98", T2IParamTypes.QwenModel);
         }
 
         public string GetOvisQwenModel()

--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorModelSupport.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorModelSupport.cs
@@ -598,7 +598,7 @@ public partial class WorkflowGenerator
 
         public string GetQwen3Vl8bModel()
         {
-            return RequireClipModel("qwen3vl_8b_fp8_scaled.safetensors", "https://huggingface.co/Comfy-Org/Ideogram-4/resolve/main/text_encoders/qwen3vl_8b_fp8_scaled.safetensors", "4ba424cf62e51392e4d1a39933e803706f4e823c1065f36aaf149c6453f66bcd", T2IParamTypes.QwenModel);
+            return RequireClipModel("qwen3vl_8b_nvfp4.safetensors", "https://huggingface.co/Comfy-Org/Ideogram-4/blob/main/text_encoders/qwen3vl_8b_nvfp4.safetensors", "e462e9e0c3b9313ae17f82040d7c77beb92d7aef3e40692d7803228dab7c3b98", T2IParamTypes.QwenModel);
         }
 
         public string GetOvisQwenModel()


### PR DESCRIPTION
Right now Swarm downloads and defaults to the regular qwen3 model, while the [official docs](https://github.com/ideogram-oss/ideogram4/blob/main/docs/model_architecture.md) and [comfy-org distribution](https://huggingface.co/Comfy-Org/Ideogram-4/tree/main/text_encoders) both use the vl variant.


I chose the fp8 scaled version instead of the nvfp4 version because I have serious concerns about TE quality degradation in this model. I know nvidia will say otherwise because they want to sell their new gpus with nvfp4 acceleration.


In my own testing I've found that the vl variant produces more coherent outputs.
# with qwen3:
<img width="896" height="1152" alt="image" src="https://github.com/user-attachments/assets/823d97ad-2429-456b-b964-ebcbe5d3a1af" />


# with qwen3vl:
<img width="896" height="1152" alt="image" src="https://github.com/user-attachments/assets/f0fce397-3a6e-429e-a9bc-d6c5fb681fda" />

## Much Better!