### PR TITLE
Highlight wildcard card on `<wc:foo>`

### DIFF
--- a/src/wwwroot/js/genpage/gentab/models.js
+++ b/src/wwwroot/js/genpage/gentab/models.js
@@ -970,8 +970,8 @@ function monitorPromptChangeForEmbed(promptText, type) {
     if (countNew != countOld || (countNew > 0 && countEndsNew != countEndsOld)) {
         sdEmbedBrowser.rebuildSelectedClasses();
     }
-    let countNewWc = promptText.split(`<wildcard`).length - 1;
-    let countOldWc = last.split(`<wildcard`).length - 1;
+    let countNewWc = (promptText.split(`<wildcard`).length - 1) + (promptText.split(`<wc`).length - 1);
+    let countOldWc = (last.split(`<wildcard`).length - 1) + (last.split(`<wc`).length - 1);
     if (countNewWc != countOldWc || (countNewWc > 0 && countEndsNew != countEndsOld)) {
         wildcardsBrowser.rebuildSelectedClasses();
     }

--- a/src/wwwroot/js/genpage/gentab/wildcards.js
+++ b/src/wwwroot/js/genpage/gentab/wildcards.js
@@ -335,7 +335,7 @@ class WildcardHelpers {
 
     /** Small util to match a wildcard syntax entry in a prompt. */
     matchWildcard(prompt, wildcard) {
-        let matcher = new RegExp(`<(wildcard(?:\\[\\d+(?:-\\d+)?\\])?):${regexEscape(wildcard)}>`, 'g');
+        let matcher = new RegExp(`<((?:wildcard|wc)(?:\\[\\d+(?:-\\d+)?\\])?):${regexEscape(wildcard)}>`, 'g');
         return prompt.match(matcher);
     }
 


### PR DESCRIPTION
Currently selecting a wildcard from the GUI adds it to the prompt box, and the wildcard's box is highlighted. However, this seems to only work when using `<wildcard:foo>`, but not `<wc:foo>`.

This PR adds support for `<wc:foo>` triggering highlight.