### PR TITLE
fix history search missing metadata for .webp images

### DIFF
--- a/src/Media/ImageFile.cs
+++ b/src/Media/ImageFile.cs
@@ -9,7 +9,6 @@ using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.Formats.Webp;
 using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.PixelFormats;
-
 using Image = SwarmUI.Utils.Image;
 using ISImage = SixLabors.ImageSharp.Image;
 using ISImage32 = SixLabors.ImageSharp.Image<SixLabors.ImageSharp.PixelFormats.Rgba32>;

--- a/src/Utils/OutputMetadataTracker.cs
+++ b/src/Utils/OutputMetadataTracker.cs
@@ -120,7 +120,7 @@ public static class OutputMetadataTracker
     }
 
     /// <summary>File format extensions that even can have metadata on them.</summary>
-    public static HashSet<string> ExtensionsWithMetadata = ["png", "jpg"];
+    public static HashSet<string> ExtensionsWithMetadata = ["png", "jpg", "webp"];
 
     /// <summary>File format extensions that require ffmpeg to process image data.</summary>
     public static HashSet<string> ExtensionsForFfmpegables = ["webm", "mp4", "mov"];


### PR DESCRIPTION
So basically history panel's text search was missing images whose filenames don't contain the search term (e.g. searching by prompt content). The searchable string on each file is built from name, metadata, fullsrc, but .webp files always had null metadata because ImageSharp's WebP decoder doesn't populate ExifProfile.

The metadata IS embedded in webp files (as EXIF UserComment, written at ImageFile.cs:306), but GetMetadata() only checked img.Metadata.ExifProfile which is null for WebP in ImageSharp 3.1.12.

Changes:

OutputMetadataTracker.cs:123 - Add "webp" to ExtensionsWithMetadata
~~OutputMetadataTracker.cs:338 - Invalidate cached entries with null Metadata for extractable formats, so stale null-metadata entries (cached before webp was in the set) get force-re-read~~
~~ImageFile.cs:224 - Fallback to ReadExifUserCommentFromRaw() when ImageSharp's ExifProfile returns null~~
~~ImageFile.cs:238-370 - New ReadExifUserCommentFromRaw() method that parses the EXIF UserComment tag (0x9286) directly from raw binary bytes, matching what the client-side ExifReader JS library does successfully~~