### PR TITLE
Allows lazy loading of preset images

### DIFF
--- a/docs/APIRoutes/BasicAPIFeatures.md
+++ b/docs/APIRoutes/BasicAPIFeatures.md
@@ -258,7 +258,7 @@ User route to get the user's own base data.
             "param_map": {
                 "key": "value"
             },
-            "preview_image": "data:base64 img"
+            "preview_image": "/ViewSpecial/Preset/Preset Title"
         }
     ],
     "language": "en",

--- a/src/Core/WebServer.cs
+++ b/src/Core/WebServer.cs
@@ -650,6 +650,17 @@ public class WebServer
             await context.Response.Body.WriteAsync(img.RawData, Program.GlobalProgramCancel);
             await context.Response.CompleteAsync();
         }
+        if (subtype == "Preset")
+        {
+            T2IPreset preset = user.GetPreset(name);
+            if (preset is not null && (preset.PreviewImage?.StartsWithFast("data:") ?? false))
+            {
+                await yieldResult(preset.PreviewImage);
+                return;
+            }
+            await context.YieldJsonOutput(null, 404, Utilities.ErrorObj("404, file not found.", "file_not_found"));
+            return;
+        }
         if (!user.IsAllowedModel(name))
         {
             Logs.Verbose($"Not showing user '{user.UserID}' sub-type '{subtype}' model image '{name}': user restriction");

--- a/src/Text2Image/T2IPreset.cs
+++ b/src/Text2Image/T2IPreset.cs
@@ -1,6 +1,7 @@
 using LiteDB;
 using Newtonsoft.Json.Linq;
 using SwarmUI.Utils;
+using SwarmUI.WebAPI;
 
 namespace SwarmUI.Text2Image;
 
@@ -51,14 +52,14 @@ public class T2IPreset
     }
 
     /// <summary>Gets networkable data about this preset.</summary>
-    public JObject NetData()
+    public JObject NetData(bool includeImage = false)
     {
         return new JObject()
         {
             ["author"] = Author,
             ["title"] = Title,
             ["description"] = Description,
-            ["preview_image"] = PreviewImage,
+            ["preview_image"] = PreviewImage.StartsWith("data:") && !includeImage ? $"/ViewSpecial/Preset/{Title}?editid={ModelsAPI.ModelEditID}" : PreviewImage,
             ["is_starred"] = IsStarred,
             ["param_map"] = JObject.FromObject(ParamMap)
         };

--- a/src/WebAPI/BasicAPIFeatures.cs
+++ b/src/WebAPI/BasicAPIFeatures.cs
@@ -31,6 +31,7 @@ public static class BasicAPIFeatures
         API.RegisterAPICall(Logout, true, Permissions.Fundamental);
         API.RegisterAPICall(InstallConfirmWS, true, Permissions.Install);
         API.RegisterAPICall(GetMyUserData, false, Permissions.FundamentalGenerateTabAccess);
+        API.RegisterAPICall(ExportUserPresets, false, Permissions.FundamentalGenerateTabAccess);
         API.RegisterAPICall(SetStarredModels, true, Permissions.FundamentalModelAccess);
         API.RegisterAPICall(SetPresetLinks, true, Permissions.FundamentalModelAccess);
         API.RegisterAPICall(AddNewPreset, true, Permissions.ManagePresets);
@@ -355,7 +356,7 @@ public static class BasicAPIFeatures
                     "param_map": {
                         "key": "value"
                     },
-                    "preview_image": "data:base64 img",
+                    "preview_image": "/ViewSpecial/Preset/Preset Title",
                     "is_starred": false
                 }
             ],
@@ -380,12 +381,52 @@ public static class BasicAPIFeatures
         return new JObject()
         {
             ["user_name"] = session.User.UserID,
-            ["presets"] = new JArray(session.User.GetAllPresets().Select(p => p.NetData()).ToArray()),
+            ["presets"] = new JArray(session.User.GetAllPresets().Select(p =>
+            {
+                JObject netData = p.NetData();
+                if (netData["preview_image"]?.ToString().StartsWithFast("data:") ?? false)
+                {
+                    netData["preview_image"] = $"/ViewSpecial/Preset/{p.Title}";
+                }
+                return netData;
+            }).ToArray()),
             ["language"] = session.User.Settings.Language,
             ["permissions"] = JArray.FromObject(session.User.GetPermissions()),
             ["starred_models"] = JObject.Parse(session.User.GetGenericData("starred_models", "full") ?? "{}"),
             ["model_preset_links"] = JObject.Parse(session.User.GetGenericData("modelpresetlinks", "full") ?? "{}"),
             ["autocompletions"] = string.IsNullOrWhiteSpace(settings.Source) ? null : new JArray(AutoCompleteListHelper.GetData(settings.Source, settings.EscapeParens, settings.Suffix, settings.SpacingMode))
+        };
+    }
+
+    [API.APIDescription("Gets the user's presets with full base64 preview images embedded.",
+        """
+            "presets": [
+                {
+                    "author": "username",
+                    "title": "Preset Title",
+                    "description": "Preset Description",
+                    "param_map": { "key": "value" },
+                    "preview_image": "data:image/jpeg;base64,...",
+                    "is_starred": false
+                }
+            ]
+        """)]
+    public static async Task<JObject> ExportUserPresets(Session session,
+        [API.APIParameter("Optional 'titles' key holding a JSON array of preset titles to include.")] JObject raw)
+    {
+        HashSet<string> wanted = null;
+        if (raw is not null && raw.TryGetValue("titles", out JToken titlesTok) && titlesTok is JArray titlesArr)
+        {
+            wanted = [.. titlesArr.Select(t => t.ToString())];
+        }
+        IEnumerable<T2IPreset> presets = session.User.GetAllPresets();
+        if (wanted is not null)
+        {
+            presets = presets.Where(p => wanted.Contains(p.Title));
+        }
+        return new JObject()
+        {
+            ["presets"] = new JArray(presets.Select(p => p.NetData()).ToArray())
         };
     }
 
@@ -439,7 +480,12 @@ public static class BasicAPIFeatures
         {
             return new JObject() { ["preset_fail"] = "A preset with that title already exists." };
         }
-        if (!string.IsNullOrWhiteSpace(preview_image) && preview_image != "imgs/model_placeholder.jpg")
+        if (is_edit && existingPreset is not null && !string.IsNullOrWhiteSpace(preview_image)
+            && !preview_image.StartsWith("data:") && !preview_image.StartsWith("/Output") && preview_image != "imgs/model_placeholder.jpg")
+        {
+            preview_image = existingPreset.PreviewImage;
+        }
+        else if (!string.IsNullOrWhiteSpace(preview_image) && preview_image != "imgs/model_placeholder.jpg")
         {
             if ((!preview_image.StartsWith("data:image/jpeg;base64,") && !preview_image.StartsWith("/Output")) || preview_image.Contains('?'))
             {

--- a/src/WebAPI/BasicAPIFeatures.cs
+++ b/src/WebAPI/BasicAPIFeatures.cs
@@ -381,15 +381,7 @@ public static class BasicAPIFeatures
         return new JObject()
         {
             ["user_name"] = session.User.UserID,
-            ["presets"] = new JArray(session.User.GetAllPresets().Select(p =>
-            {
-                JObject netData = p.NetData();
-                if (netData["preview_image"]?.ToString().StartsWithFast("data:") ?? false)
-                {
-                    netData["preview_image"] = $"/ViewSpecial/Preset/{p.Title}";
-                }
-                return netData;
-            }).ToArray()),
+            ["presets"] = new JArray(session.User.GetAllPresets().Select(p => p.NetData(false)).ToArray()),
             ["language"] = session.User.Settings.Language,
             ["permissions"] = JArray.FromObject(session.User.GetPermissions()),
             ["starred_models"] = JObject.Parse(session.User.GetGenericData("starred_models", "full") ?? "{}"),
@@ -426,7 +418,7 @@ public static class BasicAPIFeatures
         }
         return new JObject()
         {
-            ["presets"] = new JArray(presets.Select(p => p.NetData()).ToArray())
+            ["presets"] = new JArray(presets.Select(p => p.NetData(true)).ToArray())
         };
     }
 
@@ -480,12 +472,11 @@ public static class BasicAPIFeatures
         {
             return new JObject() { ["preset_fail"] = "A preset with that title already exists." };
         }
-        if (is_edit && existingPreset is not null && !string.IsNullOrWhiteSpace(preview_image)
-            && !preview_image.StartsWith("data:") && !preview_image.StartsWith("/Output") && preview_image != "imgs/model_placeholder.jpg")
+        if (preview_image is not null && preview_image.StartsWith("/ViewSpecial/"))
         {
-            preview_image = existingPreset.PreviewImage;
+            preview_image = null;
         }
-        else if (!string.IsNullOrWhiteSpace(preview_image) && preview_image != "imgs/model_placeholder.jpg")
+        if (!string.IsNullOrWhiteSpace(preview_image) && preview_image != "imgs/model_placeholder.jpg")
         {
             if ((!preview_image.StartsWith("data:image/jpeg;base64,") && !preview_image.StartsWith("/Output")) || preview_image.Contains('?'))
             {
@@ -494,6 +485,10 @@ public static class BasicAPIFeatures
             }
             ImageFile img = ImageFile.FromDataString(preview_image).ToMetadataJpg(preview_image_metadata);
             preview_image = img.AsDataString();
+        }
+        if (string.IsNullOrWhiteSpace(preview_image) && existingPreset is not null)
+        {
+            preview_image = existingPreset.PreviewImage;
         }
         T2IPreset preset = new()
         {
@@ -504,6 +499,7 @@ public static class BasicAPIFeatures
             PreviewImage = string.IsNullOrWhiteSpace(preview_image) ? "imgs/model_placeholder.jpg" : preview_image,
             IsStarred = is_starred
         };
+        Interlocked.Increment(ref ModelsAPI.ModelEditID);
         if (is_edit && existingPreset is not null && editing != title)
         {
             session.User.DeletePreset(editing);

--- a/src/wwwroot/js/genpage/gentab/presets.js
+++ b/src/wwwroot/js/genpage/gentab/presets.js
@@ -955,24 +955,26 @@ function exportPresetsButton(reuse = false) {
     if (!reuse) {
         exportingPresets = allPresets;
     }
-    let text = '';
     if (getRequiredElementById('export_preset_format_json').checked) {
-        let data = {};
-        for (let preset of exportingPresets) {
-            data[preset.title] = preset;
-        }
-        text = JSON.stringify(data, null, 4);
+        genericRequest('ExportUserPresets', { titles: exportingPresets.map(p => p.title) }, fullData => {
+            let data = {};
+            for (let preset of fullData.presets) {
+                data[preset.title] = preset;
+            }
+            getRequiredElementById('export_presets_textarea').value = JSON.stringify(data, null, 4);
+            $('#export_presets_modal').modal('show');
+        });
     }
     else { // CSV
-        text = 'name,prompt,negative_prompt,\n';
+        let text = 'name,prompt,negative_prompt,\n';
         for (let preset of exportingPresets) {
             if (preset.param_map.prompt || preset.param_map.negativeprompt) {
                 text += `"${preset.title.replace('"', '""')}","${(preset.param_map.prompt || '').replaceAll('"', '""')}","${(preset.param_map.negativeprompt || '').replaceAll('"', '""')}",\n`;
             }
         }
+        getRequiredElementById('export_presets_textarea').value = JSON.stringify(data, null, 4);
+        $('#export_presets_modal').modal('show');
     }
-    getRequiredElementById('export_presets_textarea').value = text;
-    $('#export_presets_modal').modal('show');
 }
 
 function exportPresetsDownload() {


### PR DESCRIPTION
See Discord thread: https://discord.com/channels/1243166023859961988/1243185862234210389/1517526575191556238

On my machine on a no-cache hard-reload 313 presets with an image each take ~2 minutes to finish, downloading 11,519KB twice. During this time, the models, loras, and wildcard, tabs are frozen and do not load.

This PR introduces lazy loading to presets, exactly as implemented for models. The export feature has also been updated so it fetches the image and adds it inline.

Result is `/API/GetMyUserData` reduced to 31.5kb and responds in 614ms, and all tabs load quickly.

Note: I ran `debugGenAPIDocs()` but the impact is far larger than this PR's changes so I did not include it. You probably need to run and commit the changes yourself (and maybe add a github action to sniff it).