### PR TITLE
Add KreaAttentionExtension to extension registry

### DIFF
--- a/launchtools/extension_list.fds
+++ b/launchtools/extension_list.fds
@@ -26,6 +26,17 @@
 #   'lowquality': This extension has known quality issues, such as improper implementation methods or a fully vibecoded development approach, adding significant changes outside of the intended scope, or simply is a feature that does not work as well as one might hope
 #   'none': no tags of relevance to add
 
+KreaAttentionExtension:
+  author: Timothy Dudorov
+  description: Adds custom Krea-style attention controls and workflows to SwarmUI.
+  url: https://github.com/TimothyDudorov/KreaAttentionExtension
+  license: MIT
+  ci-test: true
+  tags:
+    - parameters
+    - nodes
+    - ui
+
 FaceTools:
     author: Quaggles
     description: Adds support for CodeFormer FaceRestore and ReActor.


### PR DESCRIPTION
Hi,

I built a C# extension to wrap the Krea2PromptWeight node from ComfyUI-KJNodes (https://github.com/kijai/ComfyUI-KJNodes/blob/e27a505b3ba6ce42687fe00500deda103d9d6071/nodes/model_optimization_nodes.py#L1301) to add Krea-style attention mechanics. I tested with multiple krea 2 models and it works.  README.md contains installation and usage instructions.

Regards,
Tim