### PR TITLE
Auto-show controls for video previews on SwarmSaveAnimationWS nodes

### DIFF
--- a/src/BuiltinExtensions/ComfyUIBackend/ExtraNodes/SwarmComfyCommon/web/swarmhelper.js
+++ b/src/BuiltinExtensions/ComfyUIBackend/ExtraNodes/SwarmComfyCommon/web/swarmhelper.js
@@ -38,6 +38,7 @@ function swarmShowPreview(node, blob, isVideo) {
         element.autoplay = true;
         element.loop = true;
         element.playsInline = true;
+        element.controls = true;
     }
     element.style.width = '100%';
     element.style.height = '100%';


### PR DESCRIPTION
Right now, user needs to right-click -> Show All Controls, and is unable to pause a video otherwise.