### PR TITLE
Adds support for Final Stage group

### DIFF
--- a/docs/Features/Upscaling.md
+++ b/docs/Features/Upscaling.md
@@ -2,6 +2,15 @@
 
 (TODO)
 
+# Upscale Stages
+
+There are two places to upscale, differing in what happens after:
+
+- **Refine / Upscale** group: the refiner model samples over the upscaled result, per **Refiner Control Percentage**. Set that to `0` for an upscale-only stage.
+- **Final Stage** group: runs after the base and refiner stages are done, and nothing samples over the result, only whatever the upscaler does itself.
+    - **Final Upscale** stacks on top of Refiner Upscale, eg `1.5` refiner upscale and `2` final upscale is 3x total.
+    - **Final Upscale Method** offers the same methods as Refiner Upscale Method, minus the latent upscalers (which need a sampler after them).
+
 # Pixel Decoder (PiD)
 
 (TODO)

--- a/src/BuiltinExtensions/ComfyUIBackend/ComfyUIBackendExtension.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/ComfyUIBackendExtension.cs
@@ -606,7 +606,7 @@ public class ComfyUIBackendExtension : Extension
         }
     }
 
-    public static T2IRegisteredParam<string> CustomWorkflowParam, SamplerParam, SchedulerParam, RefinerSamplerParam, RefinerSchedulerParam, RefinerUpscaleMethod, UseIPAdapterForRevision, IPAdapterWeightType, VideoPreviewType, VideoFrameInterpolationMethod, GligenModel, YoloModelInternal, PreferredDType, UseStyleModel, TeaCacheMode, EasyCacheMode, SetClipDevice;
+    public static T2IRegisteredParam<string> CustomWorkflowParam, SamplerParam, SchedulerParam, RefinerSamplerParam, RefinerSchedulerParam, RefinerUpscaleMethod, FinalUpscaleMethod, UseIPAdapterForRevision, IPAdapterWeightType, VideoPreviewType, VideoFrameInterpolationMethod, GligenModel, YoloModelInternal, PreferredDType, UseStyleModel, TeaCacheMode, EasyCacheMode, SetClipDevice;
 
     public static T2IRegisteredParam<bool> AITemplateParam, DebugRegionalPrompting, ShiftedLatentAverageInit, UseCfgZeroStar, UseTCFG;
 
@@ -771,6 +771,10 @@ public class ComfyUIBackendExtension : Extension
         RefinerUpscaleMethod = T2IParamTypes.Register<string>(new("Refiner Upscale Method", "How to upscale the image, if upscaling is used.",
             "pixel-lanczos", Group: T2IParamTypes.GroupRefiners, OrderPriority: -1, FeatureFlag: "comfyui", ChangeWeight: 1,
             GetValues: (session) => [.. UpscalerModels, .. PidUpscaleModels(session)], DependNonDefault: T2IParamTypes.RefinerUpscale.Type.ID
+            ));
+        FinalUpscaleMethod = T2IParamTypes.Register<string>(new("Final Upscale Method", "How to upscale the image, if upscaling is used.\nNo sampler runs after this, so latent upscalers are not available here.",
+            "pixel-lanczos", Group: T2IParamTypes.GroupFinalStage, OrderPriority: -1, FeatureFlag: "comfyui", ChangeWeight: 1,
+            GetValues: (session) => [.. RefinerUpscaleMethod.Type.GetValues(session).Where(u => !u.StartsWith("latent"))]
             ));
         PixelDecoderModel = T2IParamTypes.Register<T2IModel>(new("Pixel Decoder Model", "Optionally use a PiD (Pixel Diffusion Decoder) model.",
             "", Toggleable: true, FeatureFlag: "comfyui", Group: T2IParamTypes.GroupAdvancedModelAddons, IsAdvanced: true, Subtype: "Stable-Diffusion", ChangeWeight: 4, DoNotPreview: true, OrderPriority: 14,

--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGenerator.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGenerator.cs
@@ -2694,6 +2694,27 @@ public partial class WorkflowGenerator
         return result;
     }
 
+    /// <summary>Runs the Final Stage upscale over the current media, if the user configured one and it hasn't run yet.</summary>
+    public void RunFinalStage()
+    {
+        if (!UserInput.TryGet(ComfyUIBackendExtension.FinalUpscaleMethod, out string method))
+        {
+            return;
+        }
+        double scale = UserInput.Get(T2IParamTypes.FinalUpscale, 2);
+        if (scale == 1 && method.StartsWith("pixel-"))
+        {
+            return;
+        }
+        if (UserInput.Get(T2IParamTypes.OutputIntermediateImages, false))
+        {
+            CurrentMedia.SaveOutput(CurrentVae, CurrentAudioVae, GetStableDynamicID(50000, 0));
+        }
+        IsFinalStage = true;
+        CurrentMedia = CreatePixelUpscale(method, CurrentMedia, CurrentVae, scale, UserInput.Get(T2IParamTypes.Seed) + 500);
+        IsFinalStage = false;
+    }
+
     /// <summary>Upscales raw media by any of the Final Upscale Methods.</summary>
     public WGNodeData CreatePixelUpscale(string method, WGNodeData media, WGNodeData vae, double scale, long seed)
     {

--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGenerator.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGenerator.cs
@@ -169,6 +169,9 @@ public partial class WorkflowGenerator
     /// <summary>If true, the generator is currently working on the pixel-decoder stage.</summary>
     public bool IsPixelDecoderStage = false;
 
+    /// <summary>If true, the generator is currently working on the final stage upscale.</summary>
+    public bool IsFinalStage = false;
+
     /// <summary>If true, the generator is currently working on Image2Video.</summary>
     public bool IsImageToVideo = false;
 
@@ -2668,6 +2671,61 @@ public partial class WorkflowGenerator
         CurrentTextEnc = priorTextEnc;
         CurrentVae = priorVae;
         return result;
+    }
+
+    /// <summary>Scales raw media to an exact pixel size, or does nothing if it's already that size.</summary>
+    public WGNodeData ScaleRawMedia(WGNodeData raw, int width, int height, string method = "lanczos", string id = null)
+    {
+        if (raw.Width == width && raw.Height == height)
+        {
+            return raw;
+        }
+        string scaled = CreateNode("ImageScale", new JObject()
+        {
+            ["image"] = raw.Path,
+            ["width"] = width,
+            ["height"] = height,
+            ["upscale_method"] = method,
+            ["crop"] = "disabled"
+        }, id);
+        WGNodeData result = raw.WithPath([scaled, 0]);
+        result.Width = width;
+        result.Height = height;
+        return result;
+    }
+
+    /// <summary>Upscales raw media by any of the Final Upscale Methods.</summary>
+    public WGNodeData CreatePixelUpscale(string method, WGNodeData media, WGNodeData vae, double scale, long seed)
+    {
+        WGNodeData raw = media.AsRawImage(vae);
+        int width = (int)Math.Round((raw.Width ?? UserInput.GetImageWidth()) * scale) / 16 * 16;
+        int height = (int)Math.Round((raw.Height ?? UserInput.GetImageHeight()) * scale) / 16 * 16;
+        if (method.StartsWith("pidmodel-"))
+        {
+            T2IModel pidModel = ComfyUIBackendExtension.GetPidModel(method.After("pidmodel-"), UserInput.SourceSession);
+            return ScaleRawMedia(CreatePixelDecode(pidModel, raw, vae, seed), width, height);
+        }
+        if (method.StartsWith("model-"))
+        {
+            string loaderNode = CreateNode("UpscaleModelLoader", new JObject()
+            {
+                ["model_name"] = method.After("model-")
+            });
+            string upscaledNode = CreateNode("ImageUpscaleWithModel", new JObject()
+            {
+                ["upscale_model"] = NodePath(loaderNode, 0),
+                ["image"] = raw.Path
+            });
+            WGNodeData upscaled = raw.WithPath([upscaledNode, 0]);
+            upscaled.Width = null; // the model's own scale factor is unknown here, so always correct after
+            upscaled.Height = null;
+            return ScaleRawMedia(upscaled, width, height);
+        }
+        if (method.StartsWith("pixel-"))
+        {
+            return ScaleRawMedia(raw, width, height, method.After("pixel-"));
+        }
+        throw new SwarmUserErrorException($"Upscale method '{method}' needs a sampler after it, so it can't be used as a Final Upscale Method. Use it in the Refine/Upscale group instead.");
     }
 
     /// <summary>Creates a "CLIPTextEncode" or equivalent node for the given input, applying prompt-given conditioning modifiers as relevant.</summary>

--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
@@ -1937,27 +1937,6 @@ public class WorkflowGeneratorSteps
             RunSegmentationProcessing(g, isBeforeRefiner: false);
         }, 5);
         #endregion
-        #region Final Stage
-        AddStep(g =>
-        {
-            if (!g.UserInput.TryGet(ComfyUIBackendExtension.FinalUpscaleMethod, out string method))
-            {
-                return;
-            }
-            double scale = g.UserInput.Get(T2IParamTypes.FinalUpscale, 2);
-            if (scale == 1 && method.StartsWith("pixel-"))
-            {
-                return;
-            }
-            if (g.UserInput.Get(T2IParamTypes.OutputIntermediateImages, false))
-            {
-                g.CurrentMedia.SaveOutput(g.CurrentVae, g.CurrentAudioVae, g.GetStableDynamicID(50000, 0));
-            }
-            g.IsFinalStage = true;
-            g.CurrentMedia = g.CreatePixelUpscale(method, g.CurrentMedia, g.CurrentVae, scale, g.UserInput.Get(T2IParamTypes.Seed) + 500);
-            g.IsFinalStage = false;
-        }, 6);
-        #endregion
         #region SaveImage
         AddStep(g =>
         {
@@ -2022,6 +2001,10 @@ public class WorkflowGeneratorSteps
                 bool willHaveFollowupVideo = g.UserInput.TryGet(T2IParamTypes.VideoModel, out _) || g.UserInput.Get(T2IParamTypes.Prompt, "").Contains("<extend:");
                 // Heuristic check for if this is an Init Image with no further processing, ie the initial image save is redundant because we're just wanting to extend a presaved image to a video
                 bool formedFromSingleImage = g.UserInput.Get(T2IParamTypes.InitImageCreativity, -1) == 0 && !g.UserInput.Get(T2IParamTypes.OutputIntermediateImages, false) && !g.UserInput.TryGet(T2IParamTypes.RefinerMethod, out _);
+                if (!willHaveFollowupVideo)
+                {
+                    g.RunFinalStage();
+                }
                 if (g.IsVideoModel() && !formedFromSingleImage && !willHaveFollowupVideo)
                 {
                     if (g.UserInput.TryGet(T2IParamTypes.TrimVideoStartFrames, out _) || g.UserInput.TryGet(T2IParamTypes.TrimVideoEndFrames, out _))
@@ -2144,6 +2127,10 @@ public class WorkflowGeneratorSteps
                 g.CreateImageToVideo(genInfo);
                 g.CurrentMedia = g.CurrentMedia.AsRawImage(genInfo.Vae);
                 bool hasExtend = prompt.Contains("<extend:");
+                if (!hasExtend)
+                {
+                    g.RunFinalStage();
+                }
                 if (!hasExtend && g.UserInput.TryGet(ComfyUIBackendExtension.VideoFrameInterpolationMethod, out string method) && g.UserInput.TryGet(ComfyUIBackendExtension.VideoFrameInterpolationMultiplier, out int mult) && mult > 1)
                 {
                     if (g.UserInput.Get(T2IParamTypes.OutputIntermediateImages, false))
@@ -2292,6 +2279,7 @@ public class WorkflowGeneratorSteps
                 }
                 g.CurrentMedia = conjoinedLast;
                 g.CurrentMedia.FPS = videoFps ?? g.CurrentMedia.FPS;
+                g.RunFinalStage();
                 if (g.UserInput.TryGet(ComfyUIBackendExtension.VideoFrameInterpolationMethod, out string method) && g.UserInput.TryGet(ComfyUIBackendExtension.VideoFrameInterpolationMultiplier, out int mult) && mult > 1)
                 {
                     if (saveIntermediate)

--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorSteps.cs
@@ -65,6 +65,10 @@ public class WorkflowGeneratorSteps
         }, -15);
         AddModelGenStep(g =>
         {
+            if (g.IsFinalStage)
+            {
+                return;
+            }
             if (g.IsRefinerStage && g.UserInput.TryGet(T2IParamTypes.RefinerVAE, out T2IModel rvae))
             {
                 g.LoadingVAE = g.CreateVAELoader(rvae.ToString(g.ModelFolderFormat), g.HasNode("21") ? null : "21");
@@ -102,7 +106,7 @@ public class WorkflowGeneratorSteps
         }, -14);
         AddModelGenStep(g =>
         {
-            if (g.LoadingModelType == "negative" && !g.UserInput.Get(T2IParamTypes.NegativeModelIncludeLoras, true))
+            if (g.LoadingModelType == "negative" && !g.UserInput.Get(T2IParamTypes.NegativeModelIncludeLoras, true) || g.IsFinalStage)
             {
                 return;
             }
@@ -143,6 +147,10 @@ public class WorkflowGeneratorSteps
         }, -9);
         AddModelGenStep(g =>
         {
+            if (g.IsFinalStage)
+            {
+                return;
+            }
             string applyTo = g.UserInput.Get(T2IParamTypes.FreeUApplyTo, null);
             if (g.Features.Contains("freeu") && applyTo is not null)
             {
@@ -163,6 +171,10 @@ public class WorkflowGeneratorSteps
         }, -8);
         AddModelGenStep(g =>
         {
+            if (g.IsFinalStage)
+            {
+                return;
+            }
             if (g.UserInput.TryGet(ComfyUIBackendExtension.SelfAttentionGuidanceScale, out double sagScale))
             {
                 string patched = g.CreateNode("SelfAttentionGuidance", new JObject()
@@ -243,6 +255,10 @@ public class WorkflowGeneratorSteps
         }, -6);
         AddModelGenStep(g =>
         {
+            if (g.IsFinalStage)
+            {
+                return;
+            }
             if (g.UserInput.TryGet(T2IParamTypes.SeamlessTileable, out string tileable) && tileable != "false")
             {
                 string mode = "Both";
@@ -264,6 +280,10 @@ public class WorkflowGeneratorSteps
         }, -5);
         AddModelGenStep(g =>
         {
+            if (g.IsFinalStage)
+            {
+                return;
+            }
             if (g.UserInput.TryGet(ComfyUIBackendExtension.TeaCacheMode, out string teaCacheMode) && teaCacheMode != "disabled")
             {
                 double teaCacheThreshold = g.UserInput.Get(ComfyUIBackendExtension.TeaCacheThreshold, 0.25);
@@ -370,6 +390,10 @@ public class WorkflowGeneratorSteps
         }, -4);
         AddModelGenStep(g =>
         {
+            if (g.IsFinalStage)
+            {
+                return;
+            }
             if (g.Features.Contains("aitemplate") && g.UserInput.Get(ComfyUIBackendExtension.AITemplateParam))
             {
                 string aitLoad = g.CreateNode("AITemplateLoader", new JObject()
@@ -1912,6 +1936,27 @@ public class WorkflowGeneratorSteps
             }
             RunSegmentationProcessing(g, isBeforeRefiner: false);
         }, 5);
+        #endregion
+        #region Final Stage
+        AddStep(g =>
+        {
+            if (!g.UserInput.TryGet(ComfyUIBackendExtension.FinalUpscaleMethod, out string method))
+            {
+                return;
+            }
+            double scale = g.UserInput.Get(T2IParamTypes.FinalUpscale, 2);
+            if (scale == 1 && method.StartsWith("pixel-"))
+            {
+                return;
+            }
+            if (g.UserInput.Get(T2IParamTypes.OutputIntermediateImages, false))
+            {
+                g.CurrentMedia.SaveOutput(g.CurrentVae, g.CurrentAudioVae, g.GetStableDynamicID(50000, 0));
+            }
+            g.IsFinalStage = true;
+            g.CurrentMedia = g.CreatePixelUpscale(method, g.CurrentMedia, g.CurrentVae, scale, g.UserInput.Get(T2IParamTypes.Seed) + 500);
+            g.IsFinalStage = false;
+        }, 6);
         #endregion
         #region SaveImage
         AddStep(g =>

--- a/src/Text2Image/T2IParamTypes.cs
+++ b/src/Text2Image/T2IParamTypes.cs
@@ -326,7 +326,7 @@ public class T2IParamTypes
     public static T2IRegisteredParam<string> Prompt, NegativePrompt, AspectRatio, BackendType, RefinerMethod, FreeUApplyTo, FreeUVersion, PersonalNote, VideoFormat, VideoResolution, UnsamplerPrompt, ImageFormat, MaskBehavior, ColorCorrectionBehavior, RawResolution, SeamlessTileable, SD3TextEncs, BitDepth, Webhooks, WildcardSeedBehavior, SegmentSortOrder, SegmentTargetResolution, SegmentApplyAfter, TorchCompile, VideoExtendFormat, ExactBackendID, OverridePredictionType, OverrideOutpathFormat, Text2AudioTimeSignature, Text2AudioLanguage, Text2AudioKeyScale, Text2AudioStyle;
     public static T2IRegisteredParam<int> Images, Steps, Width, Height, SideLength, BatchSize, VAETileSize, VAETileOverlap, VAETemporalTileSize, VAETemporalTileOverlap, ClipStopAtLayer, VideoFrames, VideoMotionBucket, VideoFPS, VideoSteps, RefinerSteps, CascadeLatentCompression, MaskShrinkGrow, MaskBlur, MaskGrow, SegmentMaskBlur, SegmentMaskGrow, SegmentMaskOversize, SegmentSteps, Text2VideoFrames, TrimVideoStartFrames, TrimVideoEndFrames, VideoExtendFrameOverlap;
     public static T2IRegisteredParam<long> Seed, VariationSeed, WildcardSeed, Text2AudioBPM;
-    public static T2IRegisteredParam<double> CFGScale, VariationSeedStrength, InitImageCreativity, InitImageResetToNorm, InitImageNoise, RefinerControl, RefinerUpscale, RefinerCFGScale, ReVisionStrength, AltResolutionHeightMult,
+    public static T2IRegisteredParam<double> CFGScale, VariationSeedStrength, InitImageCreativity, InitImageResetToNorm, InitImageNoise, RefinerControl, RefinerUpscale, RefinerCFGScale, FinalUpscale, ReVisionStrength, AltResolutionHeightMult,
         FreeUBlock1, FreeUBlock2, FreeUSkip1, FreeUSkip2, GlobalRegionFactor, EndStepsEarly, SamplerSigmaMin, SamplerSigmaMax, SamplerRho, VideoAugmentationLevel, VideoCFG, VideoMinCFG, Video2VideoCreativity, VideoSwapPercent, VideoExtendSwapPercent, IP2PCFG2, RegionalObjectCleanupFactor, SigmaShift, SegmentThresholdMax, SegmentCFGScale, FluxGuidanceScale, Text2AudioDuration;
     public static T2IRegisteredParam<Image> InitImage, MaskImage, VideoEndFrame;
     public static T2IRegisteredParam<AudioFile> VideoAudioInput, VideoAudioReference;
@@ -336,7 +336,7 @@ public class T2IParamTypes
     public static T2IRegisteredParam<bool> OutputIntermediateImages, DoNotSave, DoNotSaveIntermediates, ControlNetPreviewOnly, RevisionZeroPrompt, RemoveBackground, NoSeedIncrement, NoPreviews, VideoBoomerang, ModelSpecificEnhancements, UseInpaintingEncode, MaskCompositeUnthresholded, SaveSegmentMask, InitImageRecompositeMask, UseReferenceOnly, RefinerDoTiling, AutomaticVAE, ZeroNegative, FluxDisableGuidance, SmartImagePromptResizing, NoLoadModels, NoInternalSpecialHandling, ForwardRawBackendData, ForwardSwarmData, NegativeModelIncludeLoras, ContinueAfterErrors,
         PlaceholderParamGroupStarred, PlaceholderParamGroupUser1, PlaceholderParamGroupUser2, PlaceholderParamGroupUser3;
 
-    public static T2IParamGroup GroupImagePrompting, GroupCore, GroupVariation, GroupResolution, GroupSampling, GroupInitImage, GroupRefiners, GroupRefinerOverrides,
+    public static T2IParamGroup GroupImagePrompting, GroupCore, GroupVariation, GroupResolution, GroupSampling, GroupInitImage, GroupRefiners, GroupRefinerOverrides, GroupFinalStage,
         GroupAdvancedModelAddons, GroupSwarmInternal, GroupFreeU, GroupRegionalPrompting, GroupSegmentRefining, GroupSegmentOverrides, GroupAdvancedSampling, GroupAlternateGuidance, GroupVideo, GroupText2Video, GroupAdvancedVideo, GroupAdvancedVideoObscure, GroupVideoExtend, GroupText2Audio,
         GroupStarred, GroupUser1, GroupUser2, GroupUser3;
 
@@ -551,6 +551,11 @@ public class T2IParamTypes
         RefinerCFGScale = Register<double>(new("Refiner CFG Scale", "For the refiner model independently of the base model, how strongly to scale prompt input.\nHigher CFG scales tend to produce more contrast, and lower CFG scales produce less contrast.\n"
             + "Too-high values can cause corrupted/burnt images, too-low can cause nonsensical images.\n7 is a good baseline. Normal usages vary between 4 and 9.\nSome model types, such as Turbo, expect CFG around 1.",
             "7", Min: 0, Max: 100, ViewMax: 20, Step: 0.5, Examples: ["5", "6", "7", "8", "9"], OrderPriority: -4, ViewType: ParamViewType.SLIDER, Group: GroupRefinerOverrides, ChangeWeight: -3, Toggleable: true, IsAdvanced: true
+            ));
+        // ================================================ Final Stage ================================================
+        GroupFinalStage = new("Final Stage", Toggles: true, Open: false, OrderPriority: -2.5, Description: "An upscale applied after the base and refiner stages are done.\nUnlike the Refine/Upscale group, nothing samples over the result after, only whatever the upscaler does itself.");
+        FinalUpscale = Register<double>(new("Final Upscale", "How much to upscale by in the final stage.\nThis stacks on top of Refiner Upscale, so 1.5 refiner upscale and 2 final upscale is 3x total.",
+            "2", Min: 0.25, Max: 8, ViewMax: 4, Step: 0.25, OrderPriority: -2, ViewType: ParamViewType.SLIDER, Group: GroupFinalStage, DoNotPreview: true, Examples: ["1.5", "2", "4"]
             ));
         // ================================================ ControlNet ================================================
         for (int i = 1; i <= 3; i++)


### PR DESCRIPTION
<img width="672" height="320" alt="CleanShot 2026-07-30 at 10 40 13@2x" src="https://github.com/user-attachments/assets/d9cb9fec-4133-4715-a4f2-c75137fbcc6c" />

Pixel:
<img width="3542" height="1096" alt="CleanShot 2026-07-30 at 10 37 53@2x" src="https://github.com/user-attachments/assets/06ec1330-3be0-4768-89c7-57ab84f5b000" />

Model:
<img width="3576" height="1078" alt="CleanShot 2026-07-30 at 10 38 28@2x" src="https://github.com/user-attachments/assets/7a241714-2d35-4d86-ab02-d715113c2914" />

PiD Model:
<img width="3554" height="1098" alt="CleanShot 2026-07-30 at 10 39 01@2x" src="https://github.com/user-attachments/assets/b2d9c594-9b6a-443a-b741-a955e43ebdec" />

SeedVR2 support comes after