### PR TITLE
Adds context-specific right-click menu on preview images within Swarm…

### DIFF
--- a/src/BuiltinExtensions/ComfyUIBackend/ExtraNodes/SwarmComfyCommon/web/swarmhelper.js
+++ b/src/BuiltinExtensions/ComfyUIBackend/ExtraNodes/SwarmComfyCommon/web/swarmhelper.js
@@ -43,6 +43,7 @@ function swarmShowPreview(node, blob, isVideo) {
     element.style.width = '100%';
     element.style.height = '100%';
     element.style.objectFit = 'contain';
+    element.style.pointerEvents = 'auto';
     element.onload = element.onloadedmetadata = () => {
         let width = element.videoWidth || element.naturalWidth;
         let height = element.videoHeight || element.naturalHeight;


### PR DESCRIPTION
…SaveImageWS

Sorry, title is a mouthful but it's accurate.

Currently, generating an image in comfyui and right-clicking the preview shows this menu:
<img width="730" height="1470" alt="rightclick" src="https://github.com/user-attachments/assets/361fe25e-21b0-430d-9e3e-65fc91defbc4" />

Missing are the image-specific links (the current right-click menu is for a normal browser page). This PR adds it:
<img width="756" height="980" alt="CleanShot 2026-08-01 at 08 37 04@2x" src="https://github.com/user-attachments/assets/6c135a31-2998-496d-b6ad-cc23ee4bbd4a" />
