### PR TITLE
Fix upstream break; unwrap video stream

### DIFF
--- a/src/BuiltinExtensions/ComfyUIBackend/ExtraNodes/SwarmComfyCommon/SwarmKSampler.py
+++ b/src/BuiltinExtensions/ComfyUIBackend/ExtraNodes/SwarmComfyCommon/SwarmKSampler.py
@@ -141,6 +141,8 @@ def make_swarm_sampler_callback(steps, device, model, previews):
     def callback(step, x0, x, total_steps):
         pbar.update_absolute(step + 1, total_steps, None)
         if previewer:
+            if getattr(x0, "is_nested", False) and hasattr(x0, "tensors"):
+                x0 = x0.tensors[0]
             if x0.ndim == 5:
                 # video shape is [batch, channels, backwards time, width, height], for previews needs to be swapped to [forwards time, channels, width, height]
                 x0 = x0[0].permute(1, 0, 2, 3)


### PR DESCRIPTION
Fix for break introduced upstream: https://github.com/Comfy-Org/ComfyUI/pull/15196

Just unwrap this new video+audio data and grab only the video part.