### PR TITLE
Add Krea2Edit Extension (#1460)

### DIFF
--- a/launchtools/extension_list.fds
+++ b/launchtools/extension_list.fds
@@ -367,3 +367,12 @@ KreaGoneWild:
     tags:
     - parameters
     - nodes
+
+Krea2Edit:
+    author: Allen Benz
+    description: Adds support for models that require the ComfyUI-Krea2Edit nodes.
+    url: https://github.com/allenbenz/SwarmUI-Krea2Edit
+    license: MIT
+    tags:
+    - parameters
+    - nodes


### PR DESCRIPTION
Made an [extension](https://github.com/allenbenz/SwarmUI-Krea2Edit) that loops in the Krea2EditModelPatch to make things like https://huggingface.co/conradlocke/krea2-identity-edit work right and replicates what Krea2EditGroundedEncode does with swarm nodes so I think it might play nicer with other extensions/be composable.

I don't have good testing scenarios to verify how composable it is with other extensions so I don't really know.

It supports both one and two input images and exposes all the options that are available on Krea2EditModelPatch (ref boost/ref boost a/legacy crop) and exposes would have been available if Krea2EditGroundedEncode was being used (grounding_px).

It pulls in https://github.com/lbouaraba/comfyui-krea2edit and https://github.com/cubiq/ComfyUI_essentials, the latter is a old and in maintenance mode but it has the image resize node that can replicate how Krea2EditGroundedEncode resizes images.

This copies liberally from KreaGoneWild.