### PR TITLE
Adds a per-generation attention mode override dropdown (disabled/sdpa/pytorch/sage/flash), letting you opt specific models out of global SageAttention without restarting ComfyUI.

### DIFF
--- a/launchtools/extension_list.fds
+++ b/launchtools/extension_list.fds
@@ -367,3 +367,14 @@ KreaGoneWild:
     tags:
     - parameters
     - nodes
+
+SageAttentionOptout:
+    # Wraps https://github.com/EnviralDesign/comfy-sageattention-optout-customnodes by EnviralDesign
+    author: barelymining
+    description: Adds a per-generation attention mode override dropdown (disabled/sdpa/pytorch/sage/flash), letting you opt specific models out of global SageAttention without restarting ComfyUI.
+    url: https://github.com/barelymining/SwarmUI-SageAttentionOptout
+    license: MIT
+    ci-test: true
+    tags:
+    - parameters
+    - nodes


### PR DESCRIPTION
Adds the SageAttentionOptout extension which wraps the comfy-sageattention-optout-customnodes node by EnviralDesign to allow per-generation attention mode overrides without restarting ComfyUI.
