### PR TITLE
Fix edit model metadata linked preset focus steal

### DIFF
--- a/src/Pages/_Generate/GenTabModals.cshtml
+++ b/src/Pages/_Generate/GenTabModals.cshtml
@@ -129,7 +129,7 @@
 
 <!-- =================================== Model Modals =================================== -->
 
-@WebUtil.ModalHeader("edit_model_modal", """Edit Model Metadata: <input type="text" class="modal_text_extra" id="edit_model_name" placeholder="Model Name" />""")
+@WebUtil.ModalHeader("edit_model_modal", """Edit Model Metadata: <input type="text" class="modal_text_extra" id="edit_model_name" placeholder="Model Name" />""", trapFocus: false)
     <div class="modal-body">
         <div><span id="edit_model_technical_data"></span></div>
         <hr>

--- a/src/Utils/WebUtil.cs
+++ b/src/Utils/WebUtil.cs
@@ -32,11 +32,12 @@ public static class WebUtil
 """);
     }
 
-    public static HtmlString ModalHeader(string id, string title)
+    public static HtmlString ModalHeader(string id, string title, bool trapFocus = true)
     {
         string translate = title.Contains('<') ? "" : " translate";
+        string focusAttribute = trapFocus ? "" : "data-bs-focus=\"false\"";
         return new($"""
-            <div class="modal" tabindex="-1" role="dialog" id="{id}">
+            <div class="modal" {focusAttribute} tabindex="-1" role="dialog" id="{id}">
                 <div class="modal-dialog" role="document">
                     <div class="modal-content">
                         <div class="modal-header"><h5 class="modal-title{translate}">{title}</h5></div>


### PR DESCRIPTION
Bug fix where clicking the Linked Preset dropdown (`(None)` in screenshot) auto-loses focus to the model name field and makes it impossible to type into the search bar.

<img width="485" height="1021" alt="download" src="https://github.com/user-attachments/assets/9c944a39-03e5-4993-9b12-91ba835c0b7c" />
