### PR TITLE
Add ModelPaths extension to the list

### DIFF
--- a/launchtools/extension_list.fds
+++ b/launchtools/extension_list.fds
@@ -376,3 +376,12 @@ H3Attn:
     - parameters
     - nodes
     - beta
+
+ModelPaths:
+    author: Janush1981
+    description: Forwards every model folder under your model root to ComfyUI, not just the fixed set Swarm maps - LLM, insightface, ultralytics, sam, mmaudio, florence2 and the rest - so custom nodes stop re-downloading models you already have.
+    url: https://github.com/Janush1981/SwarmUI-ModelPaths
+    license: MIT
+    ci-test: true
+    tags:
+    - tools


### PR DESCRIPTION
Adds [SwarmUI-ModelPaths](https://github.com/Janush1981/SwarmUI-ModelPaths) to the
known extensions list.

**What it does:** Swarm maps eight configurable model path types plus a short hardcoded
list in `FoldersToForwardInComfyPath`. Everything else — `LLM`, `insightface`,
`ultralytics`, `sam`, `mmaudio`, `florence2`, `rembg` and so on — never reaches the
generated comfy paths file, so nodes fall back to `ComfyUI/models/` on the install drive
and re-download models that already exist on the model root. On my machine that had
silently duplicated 62 GB.

The extension discovers folders instead of taking a hand-written list: whatever exists
under `Paths.ModelRoot` is forwarded. No new setting, no filesystem scan — it lists the
immediate subdirectories of the root Swarm already required, one level deep.

It also merges duplicate folder-type keys via the `ModifyComfyYaml` hook. Nothing orders
extension init, so two extensions can claim the same key without seeing each other — I hit
this with `luts`, wanted by both PostRenderTorched and folder discovery. YAML resolves a
duplicate key last-one-wins, silently dropping the other's paths.

MIT licensed, `ci-test: true`, README in English and Ukrainian. Known limitations are
documented rather than glossed over: nodes that hardcode `models_dir` (`ace-step`) or
overwrite `folder_names_and_paths` outright (ReActor) bypass path registration entirely,
and no amount of registering fixes that.