### PR TITLE
Add CivitAI Browser to extension list

### DIFF
--- a/launchtools/extension_list.fds
+++ b/launchtools/extension_list.fds
@@ -379,7 +379,7 @@ H3Attn:
 
 CivitAIBrowser:
     author: genevera
-    description: Adds a CivitAI Browser tab to search, filter, preview, and download models from Civitai.com directly inside Swarm.
+    description: Adds a CivitAI Browser tab to search, filter, preview, and download models from civitai.com directly inside SwarmUI.
     url: https://github.com/genevera/civitai-browser
     license: MIT
     ci-test: true

--- a/launchtools/extension_list.fds
+++ b/launchtools/extension_list.fds
@@ -376,3 +376,13 @@ H3Attn:
     - parameters
     - nodes
     - beta
+
+CivitAIBrowser:
+    author: genevera
+    description: Adds a CivitAI Browser tab to search, filter, preview, and download models from Civitai.com directly inside Swarm.
+    url: https://github.com/genevera/civitai-browser
+    license: MIT
+    ci-test: true
+    tags:
+    - tabs
+    - ui


### PR DESCRIPTION
## Summary

Adds an entry to `launchtools/extension_list.fds` for the [CivitAI Browser](https://github.com/genevera/civitai-browser) extension.

## What it does

CivitAI Browser adds a tab that lets users search, filter, preview, and download models from Civitai.com directly inside SwarmUI's generation UI, without leaving the app. It supports:
- Search/filter by model type, base model, sort, period, and NSFW setting
- Paginated browsing (cursor-based for search, page-based for browse-all)
- Model detail overlay with versions, files, and preview images
- Standard download (populates the Model Downloader tab) and Turbo download (background WebSocket with live progress)
- Optional CivitAI API key support for higher rate limits / gated content

## Compliance with extension standards

- **License**: MIT
- **Self-contained**: no required external dependencies beyond CivitAI itself, which is core to the extension's purpose
- **No core hacking**: pure extension, registers its own tab/API/permission, does not modify core behavior
- **Network connections**: documented in the [README](https://github.com/genevera/civitai-browser#network-connections) — only contacts `civitai.com` and its image CDN, only on user action, no telemetry
- **No ads/paywalls/financial restrictions**
- **Styling**: dark theme matching SwarmUI's existing look, uses SwarmUI CSS variables for theming
- Includes a Playwright E2E test suite and GitHub Actions CI in the extension repo itself
- Compiles cleanly against current SwarmUI master (tagged `ci-test: true`)

## Testing

- `dotnet build` succeeds with the extension present in `src/Extensions/`
- Playwright E2E suite (8 tests) passes locally against a running SwarmUI dev server