### PR TITLE
Adds SenseNova-U1 support

### DIFF
--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGenerator.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGenerator.cs
@@ -815,7 +815,7 @@ public partial class WorkflowGenerator
                 }
             }
         }
-        else if (IsHiDreamO1())
+        else if (IsHiDreamO1() || IsSenseNovaU15())
         {
             List<JArray> refImages = [];
             int count = Math.Min(images.Count, 10);

--- a/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorModelSupport.cs
+++ b/src/BuiltinExtensions/ComfyUIBackend/WorkflowGeneratorModelSupport.cs
@@ -109,6 +109,9 @@ public partial class WorkflowGenerator
     /// <summary>Returns true if the current model is HiDream-O1 Image.</summary>
     public bool IsHiDreamO1() => IsModelCompatClass(T2IModelClassSorter.CompatHiDreamO1);
 
+    /// <summary>Returns true if the current model is SenseNova U1.5.</summary>
+    public bool IsSenseNovaU15() => IsModelCompatClass(T2IModelClassSorter.CompatSenseNovaU15);
+
     /// <summary>Returns true if the current model is Lens.</summary>
     public bool IsLens() => IsModelCompatClass(T2IModelClassSorter.CompatLens);
 
@@ -493,7 +496,7 @@ public partial class WorkflowGenerator
                 ["width"] = width
             }, id));
         }
-        else if (IsHiDreamO1()) // TODO: use VAE Family
+        else if (IsHiDreamO1() || IsSenseNovaU15()) // TODO: use VAE Family
         {
             return resultImage(CreateNode("EmptyHiDreamO1LatentImage", new JObject()
             {
@@ -1589,6 +1592,15 @@ public partial class WorkflowGenerator
             else if (IsHunyuanVideo() || IsHunyuanVideo15() || IsHunyuanImage() || IsWanVideo() || IsWanVideo22() || IsHiDream())
             {
                 string samplingNode = CreateNode("ModelSamplingSD3", new JObject()
+                {
+                    ["model"] = LoadingModel,
+                    ["shift"] = shiftVal
+                });
+                LoadingModel = [samplingNode, 0];
+            }
+            else if (IsSenseNovaU15())
+            {
+                string samplingNode = CreateNode("SenseNovaSamplingOptions", new JObject()
                 {
                     ["model"] = LoadingModel,
                     ["shift"] = shiftVal

--- a/src/Text2Image/T2IModelClassSorter.cs
+++ b/src/Text2Image/T2IModelClassSorter.cs
@@ -89,6 +89,7 @@ public class T2IModelClassSorter
         CompatZetaChroma = RegisterCompat(new() { ID = "zeta-chroma", ShortCode = "ZChr", LorasTargetTextEnc = false }),
         CompatAnima = RegisterCompat(new() { ID = "anima", ShortCode = "Anima", VaeFamily = VaeQwenImage }),
         CompatHiDreamO1 = RegisterCompat(new() { ID = "hidream-o1", ShortCode = "HiDrO1", LorasTargetTextEnc = false }),
+        CompatSenseNovaU15 = RegisterCompat(new() { ID = "sensenova-u1.5", ShortCode = "SNU15", LorasTargetTextEnc = false }),
         CompatLens = RegisterCompat(new() { ID = "lens", ShortCode = "Lens", LorasTargetTextEnc = false, VaeFamily = VaeFlux2 }),
         CompatPiD = RegisterCompat(new() { ID = "pid", ShortCode = "PiD", LorasTargetTextEnc = false }),
         CompatPixelDiT = RegisterCompat(new() { ID = "pixeldit", ShortCode = "PixDiT", LorasTargetTextEnc = false }),
@@ -246,6 +247,7 @@ public class T2IModelClassSorter
         bool isHiDreamLora(JObject h) => hasKey(h, "double_stream_blocks.0.block.ff_i.shared_experts.w1.lora_A.weight");
         bool isHiDreamO1(JObject h) => (h.ContainsKey("model.t_embedder1.mlp.0.weight") && h.ContainsKey("model.t_embedder1.mlp.0.bias"));
         bool isHiDreamO1Lora(JObject h) => hasLoraKey(h, "final_layer2.linear") && hasLoraKey(h, "language_model.layers.0.self_attn.q_proj");
+        bool isSenseNovaU15(JObject h) => tryGetKey(h, "fm_modules.vision_model_mot_gen.embeddings.patch_embedding.weight", out JToken visionTok) && visionTok["shape"].ToArray()[0].Value<long>() == 1024 && tryGetKey(h, "language_model.model.layers.0.self_attn.q_proj_mot_gen.weight", out JToken queryTok) && queryTok["shape"].ToArray()[0].Value<long>() == 4096;
         bool isChroma(JObject h) => hasKey(h, "distilled_guidance_layer.in_proj.bias") && hasKey(h, "double_blocks.0.img_attn.proj.bias");
         bool isChromaRadiance(JObject h) => hasKey(h, "nerf_image_embedder.embedder.0.bias");
         bool isPiD(JObject h) => h.ContainsKey("net.lq_proj.latent_proj.0.weight") && h.ContainsKey("net.pixel_blocks.0.attn.q_norm.weight") && h.ContainsKey("net.pixel_blocks.0.compress_to_attn.weight");
@@ -857,6 +859,10 @@ public class T2IModelClassSorter
         Register(new() { ID = "hidream-o1", CompatClass = CompatHiDreamO1, Name = "HiDream O1 Image", StandardWidth = 2048, StandardHeight = 2048, IsThisModelOfClass = (m, h) =>
         {
             return isHiDreamO1(h);
+        }});
+        Register(new() { ID = "sensenova-u1.5", CompatClass = CompatSenseNovaU15, Name = "SenseNova U1.5", StandardWidth = 1024, StandardHeight = 1024, IsThisModelOfClass = (m, h) =>
+        {
+            return isSenseNovaU15(h);
         }});
         Register(new() { ID = "hidream-o1/lora", CompatClass = CompatHiDreamO1, Name = "HiDream O1 LoRA", StandardWidth = 2048, StandardHeight = 2048, IsThisModelOfClass = (m, h) =>
         {


### PR DESCRIPTION
Model goes in Stable-Diffusions.

Full-fat weights: https://huggingface.co/t8star/SenseNova-U1.5-Comfy
but my int8_convrot works fine: https://huggingface.co/jtreminio/SenseNova-U1.5-8B-MoT-int8_convrot/blob/main/SenseNova-U1.5-8B-MoT-int8_convrot.safetensors

<img width="1809" height="760" alt="CleanShot 2026-09-01 at 07 35 11" src="https://github.com/user-attachments/assets/63e91746-35a9-4da0-a85b-b2318b9d663b" />
