### PR TITLE
Nested bracket syntax from middle-out

### DIFF
--- a/SwarmUITests/PromptHandlerTests.cs
+++ b/SwarmUITests/PromptHandlerTests.cs
@@ -75,6 +75,8 @@ public class PromptHandlerTests : SwarmUITest
         Assert.That(LegacyPromptParser.Convert("(layers of [a|b] features:1.5)"), Is.EqualTo("<weight[1.5]:layers of <alternate:a,b> features>"));
         Assert.That(LegacyPromptParser.Convert("(<weight[2]:layers of [a|b] features>:1.5)"), Is.EqualTo("<weight[1.5]:<weight[2]:layers of <alternate:a,b> features>>"));
         Assert.That(LegacyPromptParser.Convert("(<weight[2]:layers of [some (weighted:3)|b] features>:1.5)"), Is.EqualTo("<weight[1.5]:<weight[2]:layers of <alternate:some <weight[3]:weighted>,b> features>>"));
+        Assert.That(LegacyPromptParser.Convert("[rating!=g]"), Is.EqualTo("[rating!=g]"));
+        Assert.That(LegacyPromptParser.Convert("masterpiece, <trigger>, <q:tags/deepghs.danbooru2024[rating!=g]>"), Is.EqualTo("masterpiece, <trigger>, <q:tags/deepghs.danbooru2024[rating!=g]>"));
         Assert.That(LegacyPromptParser.Convert("\\(hello world!:1.5\\)"), Is.EqualTo("(hello world!:1.5)"));
         Assert.That(LegacyPromptParser.Convert("\\(hello (world:2)!:1.5\\)"), Is.EqualTo("(hello <weight[2]:world>!:1.5)"));
         Assert.That(LegacyPromptParser.Convert("\\(hello (world \\(and all who inhabit it\\):2)!:1.5\\)"), Is.EqualTo("(hello <weight[2]:world (and all who inhabit it)>!:1.5)"));

--- a/src/Utils/LegacyPromptParser.cs
+++ b/src/Utils/LegacyPromptParser.cs
@@ -16,8 +16,8 @@ public static class LegacyPromptParser
         {
             return val;
         }
-        val = ConvertParenWeights(val);
         val = ConvertBracketSyntaxes(val);
+        val = ConvertParenWeights(val);
         return val;
     }
 
@@ -172,6 +172,7 @@ public static class LegacyPromptParser
         end = -1;
         converted = null;
         int nest = 0;
+        int parenNest = 0;
         List<int> colons = [];
         List<int> pipes = [];
         for (int i = start + 1; i < val.Length; i++)
@@ -204,11 +205,19 @@ public static class LegacyPromptParser
                 }
                 nest--;
             }
-            else if (val[i] == ':' && nest == 0 && pipes.Count == 0)
+            else if (val[i] == '(')
+            {
+                parenNest++;
+            }
+            else if (val[i] == ')' && parenNest > 0)
+            {
+                parenNest--;
+            }
+            else if (val[i] == ':' && nest == 0 && parenNest == 0 && pipes.Count == 0)
             {
                 colons.Add(i);
             }
-            else if (val[i] == '|' && nest == 0 && colons.Count == 0)
+            else if (val[i] == '|' && nest == 0 && parenNest == 0 && colons.Count == 0)
             {
                 pipes.Add(i);
             }
@@ -245,7 +254,7 @@ public static class LegacyPromptParser
             converted = val[start..(end + 1)];
             return true;
         }
-        converted = ConvertBracketSyntaxes(control);
+        converted = val[start..(end + 1)];
         return true;
     }
 


### PR DESCRIPTION
https://discord.com/channels/1243166023859961988/1243185862234210389/1544409905342193684

starting with `<q:tags/deepghs.danbooru2024[rating!=g]>`

current behavior works from the outside in:
* parentheses pass: no change -> `<q:tags/deepghs.danbooru2024[rating!=g]>`
* square-bracket pass: `[rating!=g]` does not match a supported bracket form, but its brackets are removed anyway -> `<q:tags/deepghs.danbooru2024rating!=g>`

proposal:
* Work from the inside out by processing square brackets before parentheses
* Only modify bracket syntax the parser knows how to convert, such as `[a|b]` or `[from:to:0.5]`
* If a bracket expression is not recognized, leave the entire expression unchanged

result:
- square-bracket pass: `[rating!=g]` not recognized as legacy prompt syntax, remains unchanged
- parentheses pass: there are no parentheses, remains unchanged
- quarry receives the original tag: `<q:tags/deepghs.danbooru2024[rating!=g]>`

your nested syntax still works:
```
(layers of [a|b] features:1.5)
-> (layers of <alternate:a,b> features:1.5)
-> <weight[1.5]:layers of <alternate:a,b> features>
```