### PR TITLE
Fix RenameModel authorization check applying to wrong path

### DIFF
--- a/src/WebAPI/ModelsAPI.cs
+++ b/src/WebAPI/ModelsAPI.cs
@@ -888,7 +888,7 @@ public static class ModelsAPI
         (string oldNameNoExt, string ext) = match.Name.BeforeAndAfterLast('.');
         newName = newName.BeforeLast('.');
         newName = Utilities.StrictFilenameClean(newName).Trim().Trim('/').Replace(' ', '_');
-        if (string.IsNullOrWhiteSpace(newName) || !session.User.IsAllowedModel(oldName))
+        if (string.IsNullOrWhiteSpace(newName) || !session.User.IsAllowedModel(newName))
         {
             return new JObject() { ["error"] = "Model new name is not valid." };
         }


### PR DESCRIPTION
## Bug

In `ModelsAPI.RenameModel`, after sanitizing `newName` (the destination path/subfolder for the move), the validity check re-checks `session.User.IsAllowedModel(oldName)` again instead of validating `newName`:

```csharp
newName = Utilities.StrictFilenameClean(newName).Trim().Trim('/').Replace(' ', '_');
if (string.IsNullOrWhiteSpace(newName) || !session.User.IsAllowedModel(oldName))
```

`oldName` was already validated by `IsAllowedModel(oldName)` earlier in the method, so this second check is a redundant no-op on the source path. The destination path (`newName`) — which can place the model in a different subfolder — is never checked against the user's model whitelist/blacklist restrictions.

## Impact

A user permitted to rename/move a given model (i.e. allowed to touch the source path) can move it into any subfolder, including ones they should be restricted from writing to per their role's model permissions.

## Fix

Validate `newName` instead of re-checking `oldName`:

```csharp
if (string.IsNullOrWhiteSpace(newName) || !session.User.IsAllowedModel(newName))
```

This is a one-line change, no behavior change for users with unrestricted model access.